### PR TITLE
Support for new Labels API

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -1,5 +1,5 @@
 # https://docs.microsoft.com/en-us/nuget/concepts/package-versioning : Major.Minor.Patch[-Suffix]
-$packageVersion = "5.0.0"
+$packageVersion = "6.0.0-rc1"
 $project = "..\src\ClashOfClans\ClashOfClans.csproj"
 $configuration = "Release"
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -1,5 +1,5 @@
 # https://docs.microsoft.com/en-us/nuget/concepts/package-versioning : Major.Minor.Patch[-Suffix]
-$packageVersion = "6.0.0-rc2"
+$packageVersion = "6.0.0-rc3"
 $project = "..\src\ClashOfClans\ClashOfClans.csproj"
 $configuration = "Release"
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -1,5 +1,5 @@
 # https://docs.microsoft.com/en-us/nuget/concepts/package-versioning : Major.Minor.Patch[-Suffix]
-$packageVersion = "6.0.0-rc1"
+$packageVersion = "6.0.0-rc2"
 $project = "..\src\ClashOfClans\ClashOfClans.csproj"
 $configuration = "Release"
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -1,5 +1,5 @@
 # https://docs.microsoft.com/en-us/nuget/concepts/package-versioning : Major.Minor.Patch[-Suffix]
-$packageVersion = "6.0.0-rc3"
+$packageVersion = "6.0.0"
 $project = "..\src\ClashOfClans\ClashOfClans.csproj"
 $configuration = "Release"
 

--- a/index.md
+++ b/index.md
@@ -25,12 +25,13 @@ var playerTag = "[player tag]";
 var clanTag = "[clan tag]";
 ```
 
-## Define `using`-statements
+## Add `using`-directives
 
 
 ```C#
 using ClashOfClans;
 using ClashOfClans.Models;
+using ClashOfClans.Search;
 ```
 
 ## Get information about a single clan by clan tag
@@ -42,7 +43,7 @@ var clan = await coc.Clans.GetClanAsync(clanTag);
 Console.WriteLine($"Clan '{clan.Name}' is a level {clan.ClanLevel} clan and has {clan.Members} members");
 ```
 
-    Clan 'Storm Nation' is a level 16 clan and has 47 members
+    Clan 'Storm Nation' is a level 17 clan and has 49 members
     
 
 ## Retrieve clan's clan war log
@@ -56,10 +57,10 @@ var clan = await coc.Clans.GetClanAsync(clanTag);
 
 if (clan.IsWarLogPublic == true)
 {
-    var warLog = await coc.Clans.GetClanWarLogAsync(clanTag);
+    var warLog = (ClanWarLog)await coc.Clans.GetClanWarLogAsync(clanTag);
 
     // Take only last 10 wars
-    foreach (var war in warLog.Items.Take(10))
+    foreach (var war in warLog.Take(10))
     {
         Console.WriteLine($"{war.EndTime.ToString("s")} = {war.Result.ToString()[0]}: {Statistics(war.Clan)} vs {Statistics(war.Opponent)}");
     }
@@ -68,16 +69,16 @@ if (clan.IsWarLogPublic == true)
 string Statistics(WarClan warClan) => $"{warClan.Name} [{warClan.Stars}\u2605/{warClan.DestructionPercentage}%]";
 ```
 
+    2019-11-11T19:23:59 = W: Storm Nation [138★/92,84%] vs dutch lotus cw [68★/38,24%]
+    2019-11-09T17:48:34 = L: Storm Nation [88★/49,56%] vs вєуσи∂ ιиfιиιту [150★/100%]
+    2019-11-07T16:03:26 = W: Storm Nation [145★/96,54%] vs Farm X3 [72★/40,46%]
+    2019-11-05T14:25:21 = L: Storm Nation [95★/51,84%] vs MALAYA ALL FARM [150★/100%]
     2019-11-01T18:51:49 = L: Storm Nation [92★/52,2%] vs War Farmers [135★/91,3%]
     2019-10-30T17:05:43 = L: Storm Nation [100★/56,4%] vs MALAYA ALL FARM [150★/100%]
     2019-10-28T15:33:35 = W: Storm Nation [150★/100%] vs "Millenium" [100★/60,32%]
     2019-10-26T14:06:57 = L: Storm Nation [88★/65,4%] vs Sylhet Royals [137★/92,62%]
     2019-10-24T10:12:43 = W: Storm Nation [141★/93,82%] vs 12th man clan [101★/57,16%]
     2019-10-22T04:37:00 = L: Storm Nation [37★/26,88%] vs USA fun [150★/100%]
-    2019-10-20T02:39:37 = W: Storm Nation [139★/92,7%] vs Melbourne 1.1 [85★/47,22%]
-    2019-10-18T00:28:52 = W: Storm Nation [131★/87,28%] vs Farming PEK's [71★/41,12%]
-    2019-10-15T20:55:44 = L: Storm Nation [91★/50,84%] vs kelate sohorr [126★/84%]
-    2019-10-13T19:23:48 = L: Storm Nation [90★/51,3%] vs War Snipers 2.4 [150★/100%]
     
 
 ## Get information about a single player by player tag
@@ -96,8 +97,8 @@ if (player.Clan != null)
 }
 ```
 
-    '--[t0m1]--' has 4510 🏆 and 1981 war ⭐
-    '--[t0m1]--' is a member of 'Storm Nation' and has a donation ratio 284/40=7,10
+    '--[t0m1]--' has 4441 🏆 and 2016 war ⭐
+    '--[t0m1]--' is a member of 'Storm Nation' and has a donation ratio 657/319=2,06
     
 
 ## List leagues
@@ -105,11 +106,11 @@ if (player.Clan != null)
 
 ```C#
 var coc = new ClashOfClansApi(token);
-var leagues = await coc.Leagues.GetLeaguesAsync();
+var leagues = (LeagueList)await coc.Leagues.GetLeaguesAsync();
 
-Console.WriteLine($"Total amount of leagues: {leagues.Items.Count}");
+Console.WriteLine($"Total amount of leagues: {leagues.Count}");
 
-foreach (var league in leagues.Items)
+foreach (var league in leagues)
 {
     Console.WriteLine($"Id: {league.Id}, Name: {league.Name}");
 }
@@ -146,11 +147,11 @@ foreach (var league in leagues.Items)
 
 ```C#
 var coc = new ClashOfClansApi(token);
-var locations = await coc.Locations.GetLocationsAsync();
+var locations = (LocationList)await coc.Locations.GetLocationsAsync();
 
-Console.WriteLine($"Total amount of locations: {locations.Items.Count}");
+Console.WriteLine($"Total amount of locations: {locations.Count}");
 
-foreach (var location in locations.Items.Where(l => l.Name.StartsWith("E")))
+foreach (var location in locations.Where(l => l.Name.StartsWith("E")))
 {
     Console.Write($"Id: {location.Id}, Name: {location.Name}, IsCountry: {location.IsCountry}");
     if (location.IsCountry == true)

--- a/src/ClashOfClans.App/ClashOfClans.App.csproj
+++ b/src/ClashOfClans.App/ClashOfClans.App.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClashOfClans" Version="6.0.0-rc2" />
+    <PackageReference Include="ClashOfClans" Version="6.0.0-rc3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
   </ItemGroup>
 

--- a/src/ClashOfClans.App/ClashOfClans.App.csproj
+++ b/src/ClashOfClans.App/ClashOfClans.App.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClashOfClans" Version="5.0.0" />
+    <PackageReference Include="ClashOfClans" Version="6.0.0-rc1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/ClashOfClans.App/ClashOfClans.App.csproj
+++ b/src/ClashOfClans.App/ClashOfClans.App.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClashOfClans" Version="6.0.0-rc3" />
+    <PackageReference Include="ClashOfClans" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
   </ItemGroup>
 

--- a/src/ClashOfClans.App/ClashOfClans.App.csproj
+++ b/src/ClashOfClans.App/ClashOfClans.App.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="ClashOfClans" Version="6.0.0-rc2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ClashOfClans.App/ClashOfClans.App.csproj
+++ b/src/ClashOfClans.App/ClashOfClans.App.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClashOfClans" Version="6.0.0-rc1" />
+    <PackageReference Include="ClashOfClans" Version="6.0.0-rc2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/ClashOfClans.App/Examples/LabelsExamples.cs
+++ b/src/ClashOfClans.App/Examples/LabelsExamples.cs
@@ -1,0 +1,44 @@
+﻿using ClashOfClans.Models;
+using System;
+using System.Threading.Tasks;
+
+namespace ClashOfClans.App.Examples
+{
+    public class LabelsExamples
+    {
+        private readonly string token;
+
+        public LabelsExamples(string token)
+        {
+            this.token = token;
+        }
+
+        /// <summary>
+        /// List clan labels
+        /// </summary>
+        public async Task ListClanLabels()
+        {
+            var coc = new ClashOfClansApi(token);
+            var labels = (LabelList)await coc.Labels.GetClanLabelsAsync();
+
+            foreach (var label in labels)
+            {
+                Console.WriteLine($"Id: {label.Id}, Name: {label.Name}");
+            }
+        }
+
+        /// <summary>
+        /// List player labels
+        /// </summary>
+        public async Task ListPlayerLabels()
+        {
+            var coc = new ClashOfClansApi(token);
+            var labels = (LabelList)await coc.Labels.GetPlayerLabelsAsync();
+
+            foreach (var label in labels)
+            {
+                Console.WriteLine($"Id: {label.Id}, Name: {label.Name}");
+            }
+        }
+    }
+}

--- a/src/ClashOfClans.App/Examples/LeaguesExamples.cs
+++ b/src/ClashOfClans.App/Examples/LeaguesExamples.cs
@@ -1,4 +1,5 @@
-﻿using ClashOfClans.Search;
+﻿using ClashOfClans.Models;
+using ClashOfClans.Search;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -48,7 +49,7 @@ namespace ClashOfClans.App.Examples
         public async Task GetLeagueSeasons()
         {
             var coc = new ClashOfClansApi(token);
-            var leagues = (await coc.Leagues.GetLeaguesAsync()).Items;
+            var leagues = (LeagueList)await coc.Leagues.GetLeaguesAsync();
             var legendLeague = leagues["Legend League"];
             var seasons = await coc.Leagues.GetLeagueSeasonsAsync(legendLeague.Id);
 
@@ -66,7 +67,7 @@ namespace ClashOfClans.App.Examples
         public async Task GetLeagueSeasonRankings()
         {
             var coc = new ClashOfClansApi(token);
-            var leagues = (await coc.Leagues.GetLeaguesAsync()).Items;
+            var leagues = (LeagueList)await coc.Leagues.GetLeaguesAsync();
             var legendLeague = leagues["Legend League"];
             var seasons = await coc.Leagues.GetLeagueSeasonsAsync(legendLeague.Id);
             var lastSeason = seasons.Items.Last();

--- a/src/ClashOfClans.App/Examples/LeaguesExamples.cs
+++ b/src/ClashOfClans.App/Examples/LeaguesExamples.cs
@@ -48,7 +48,7 @@ namespace ClashOfClans.App.Examples
         public async Task GetLeagueSeasons()
         {
             var coc = new ClashOfClansApi(token);
-            var leagues = await coc.Leagues.GetLeaguesAsync();
+            var leagues = (await coc.Leagues.GetLeaguesAsync()).Items;
             var legendLeague = leagues["Legend League"];
             var seasons = await coc.Leagues.GetLeagueSeasonsAsync(legendLeague.Id);
 
@@ -66,7 +66,7 @@ namespace ClashOfClans.App.Examples
         public async Task GetLeagueSeasonRankings()
         {
             var coc = new ClashOfClansApi(token);
-            var leagues = await coc.Leagues.GetLeaguesAsync();
+            var leagues = (await coc.Leagues.GetLeaguesAsync()).Items;
             var legendLeague = leagues["Legend League"];
             var seasons = await coc.Leagues.GetLeagueSeasonsAsync(legendLeague.Id);
             var lastSeason = seasons.Items.Last();

--- a/src/ClashOfClans.App/Examples/LocationsExamples.cs
+++ b/src/ClashOfClans.App/Examples/LocationsExamples.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ClashOfClans.Models;
+using System;
 using System.Threading.Tasks;
 
 namespace ClashOfClans.App.Examples
@@ -46,7 +47,7 @@ namespace ClashOfClans.App.Examples
         public async Task GetClanRankingsForASpecificLocation()
         {
             var coc = new ClashOfClansApi(token);
-            var locations = (await coc.Locations.GetLocationsAsync()).Items;
+            var locations = (LocationList)await coc.Locations.GetLocationsAsync();
             var location = locations["Finland"];
 
             Console.WriteLine($"Clan rankings for {location.Name}");

--- a/src/ClashOfClans.App/Examples/LocationsExamples.cs
+++ b/src/ClashOfClans.App/Examples/LocationsExamples.cs
@@ -46,7 +46,7 @@ namespace ClashOfClans.App.Examples
         public async Task GetClanRankingsForASpecificLocation()
         {
             var coc = new ClashOfClansApi(token);
-            var locations = await coc.Locations.GetLocationsAsync();
+            var locations = (await coc.Locations.GetLocationsAsync()).Items;
             var location = locations["Finland"];
 
             Console.WriteLine($"Clan rankings for {location.Name}");

--- a/src/ClashOfClans.App/Program.cs
+++ b/src/ClashOfClans.App/Program.cs
@@ -42,6 +42,11 @@ namespace ClashOfClans.App
                 await locationsExamples.ListLocations();
                 await locationsExamples.GetLocationInformation();
                 await locationsExamples.GetClanRankingsForASpecificLocation();
+
+                // Access labels
+                var labelsExamples = new LabelsExamples(token);
+                await labelsExamples.ListClanLabels();
+                await labelsExamples.ListPlayerLabels();
             }
             catch (ClashOfClansException ex)
             {

--- a/src/ClashOfClans.Tests/ClansTests.cs
+++ b/src/ClashOfClans.Tests/ClansTests.cs
@@ -102,11 +102,11 @@ namespace ClashOfClans.Tests
                 taskList.Add(_coc.Clans.GetClanMembersAsync(clanTag));
             }
 
-            foreach (var memberList in await Task.WhenAll(taskList))
+            foreach (ClanMemberList memberList in await Task.WhenAll(taskList))
             {
                 // Assert
                 Assert.IsNotNull(memberList);
-                Trace.WriteLine(memberList.Items.Dump());
+                Trace.WriteLine(memberList.Dump());
             }
         }
 
@@ -125,10 +125,10 @@ namespace ClashOfClans.Tests
             // Assert
             Assert.IsTrue(taskList.Any(), "Test data does not contain a clan with public war log!");
 
-            foreach (var warLog in await Task.WhenAll(taskList))
+            foreach (ClanWarLog warLog in await Task.WhenAll(taskList))
             {
                 Assert.IsNotNull(warLog);
-                Trace.WriteLine(warLog.Items.Dump());
+                Trace.WriteLine(warLog.Dump());
             }
         }
 

--- a/src/ClashOfClans.Tests/ClansTests.cs
+++ b/src/ClashOfClans.Tests/ClansTests.cs
@@ -73,7 +73,7 @@ namespace ClashOfClans.Tests
         {
             // Arrange
             var taskList = new List<Task<Clan>>();
-            var clanTags = _clans.Items.Select(c => c.Tag).ToList();
+            var clanTags = _clans.Select(c => c.Tag).ToList();
             clanTags.AddRange(ClanTags);
 
             // Act
@@ -94,10 +94,10 @@ namespace ClashOfClans.Tests
         public async Task ListClanMembers()
         {
             // Arrange
-            var taskList = new List<Task<ClanMemberList>>();
+            var taskList = new List<Task<QueryResult<ClanMemberList>>>();
 
             // Act
-            foreach (var clanTag in ClanTags.Append(GetRandom(_clans.Items).Tag))
+            foreach (var clanTag in ClanTags.Append(GetRandom(_clans).Tag))
             {
                 taskList.Add(_coc.Clans.GetClanMembersAsync(clanTag));
             }
@@ -106,7 +106,7 @@ namespace ClashOfClans.Tests
             {
                 // Assert
                 Assert.IsNotNull(memberList);
-                Trace.WriteLine(memberList.Dump());
+                Trace.WriteLine(memberList.Items.Dump());
             }
         }
 
@@ -114,10 +114,10 @@ namespace ClashOfClans.Tests
         public async Task RetrieveClansClanWarLog()
         {
             // Arrange
-            var taskList = new List<Task<ClanWarLog>>();
+            var taskList = new List<Task<QueryResult<ClanWarLog>>>();
 
             // Act
-            foreach (var clan in _clans.Items.Where(c => c.IsWarLogPublic == true))
+            foreach (var clan in _clans.Where(c => c.IsWarLogPublic == true))
             {
                 taskList.Add(_coc.Clans.GetClanWarLogAsync(clan.Tag));
             }
@@ -128,7 +128,7 @@ namespace ClashOfClans.Tests
             foreach (var warLog in await Task.WhenAll(taskList))
             {
                 Assert.IsNotNull(warLog);
-                Trace.WriteLine(warLog.Dump());
+                Trace.WriteLine(warLog.Items.Dump());
             }
         }
 
@@ -137,7 +137,7 @@ namespace ClashOfClans.Tests
         {
             // Arrange
             var taskList = new List<Task<ClanWar>>();
-            var clanTags = _clans.Items.Where(c => c.IsWarLogPublic == true).Select(c => c.Tag).ToList();
+            var clanTags = _clans.Where(c => c.IsWarLogPublic == true).Select(c => c.Tag).ToList();
 
             foreach (var clanTag in ClanTags)
             {
@@ -167,7 +167,7 @@ namespace ClashOfClans.Tests
         {
             // Arrange
             var taskList = new List<Task<ClanWarLeagueGroup>>();
-            var clanTags = _clans.Items.Where(c => c.IsWarLogPublic == true).Select(c => c.Tag).ToList();
+            var clanTags = _clans.Where(c => c.IsWarLogPublic == true).Select(c => c.Tag).ToList();
             clanTags.AddRange(ClanTags);
 
             // Act

--- a/src/ClashOfClans.Tests/ClansTests.cs
+++ b/src/ClashOfClans.Tests/ClansTests.cs
@@ -56,7 +56,7 @@ namespace ClashOfClans.Tests
                 searchResult.Items.ToList().ForEach(clan =>
                 {
                     Assert.AreEqual(locationName, clan.Location.Name);
-                    Trace.WriteLine(clan);
+                    Trace.WriteLine(clan.Dump());
                 });
 
                 query.After = searchResult.Paging.Cursors.After;

--- a/src/ClashOfClans.Tests/ClashOfClans.Tests.csproj
+++ b/src/ClashOfClans.Tests/ClashOfClans.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
   </ItemGroup>

--- a/src/ClashOfClans.Tests/DumpExtensions.cs
+++ b/src/ClashOfClans.Tests/DumpExtensions.cs
@@ -16,9 +16,9 @@ namespace ClashOfClans.Tests
         {
             var sb = new StringBuilder();
 
-            if (warLog.Items != null)
+            if (warLog != null)
             {
-                foreach (var entry in warLog.Items.Where(w => w.Opponent.Tag != null))
+                foreach (var entry in warLog.Where(w => w.Opponent.Tag != null))
                 {
                     sb.Append(Environment.NewLine);
                     sb.Append(entry.Dump());
@@ -156,9 +156,9 @@ namespace ClashOfClans.Tests
         {
             var sb = new StringBuilder();
 
-            if (list.Items != null)
+            if (list != null)
             {
-                foreach (var member in list.Items)
+                foreach (var member in list)
                 {
                     sb.Append($"{member.Tag}/{member.Name}, donations {member.Donations}/{member.DonationsReceived}");
                     sb.Append($"={((member.DonationsReceived != 0) ? member.Donations/(float)member.DonationsReceived : -1)}");

--- a/src/ClashOfClans.Tests/DumpExtensions.cs
+++ b/src/ClashOfClans.Tests/DumpExtensions.cs
@@ -7,6 +7,8 @@ namespace ClashOfClans.Tests
 {
     public static class DumpExtensions
     {
+        public static string Dump(this Label label) => $"Id: {label.Id}, name: {label.Name}";
+
         public static string Dump(this Clan clan)
         {
             return $"Tag: {clan.Tag}, name: {clan.Name}, level: {clan.ClanLevel}, members: {clan.Members}";

--- a/src/ClashOfClans.Tests/LabelsTests.cs
+++ b/src/ClashOfClans.Tests/LabelsTests.cs
@@ -1,4 +1,5 @@
-﻿using ClashOfClans.Search;
+﻿using ClashOfClans.Models;
+using ClashOfClans.Search;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -14,11 +15,11 @@ namespace ClashOfClans.Tests
             // Arrange
 
             // Act
-            var labels = await _coc.Labels.GetClanLabelsAsync();
+            var labels = (LabelList)await _coc.Labels.GetClanLabelsAsync();
 
             // Assert
-            Assert.IsNotNull(labels.Items);
-            labels.Items.ForEach(label => Trace.WriteLine(label.Dump()));
+            Assert.IsNotNull(labels);
+            labels.ForEach(label => Trace.WriteLine(label.Dump()));
         }
 
         [TestMethod]
@@ -32,11 +33,11 @@ namespace ClashOfClans.Tests
             };
 
             // Act
-            var labels = await _coc.Labels.GetClanLabelsAsync(query);
+            var labels = (LabelList)await _coc.Labels.GetClanLabelsAsync(query);
 
             // Assert
-            Assert.IsNotNull(labels.Items);
-            Assert.AreEqual(limit, labels.Items.Count);
+            Assert.IsNotNull(labels);
+            Assert.AreEqual(limit, labels.Count);
         }
 
         [TestMethod]
@@ -45,11 +46,11 @@ namespace ClashOfClans.Tests
             // Arrange
 
             // Act
-            var labels = await _coc.Labels.GetPlayerLabelsAsync();
+            var labels = (LabelList)await _coc.Labels.GetPlayerLabelsAsync();
 
             // Assert
-            Assert.IsNotNull(labels.Items);
-            labels.Items.ForEach(label => Trace.WriteLine(label.Dump()));
+            Assert.IsNotNull(labels);
+            labels.ForEach(label => Trace.WriteLine(label.Dump()));
         }
 
         [TestMethod]
@@ -63,11 +64,11 @@ namespace ClashOfClans.Tests
             };
 
             // Act
-            var labels = await _coc.Labels.GetPlayerLabelsAsync(query);
+            var labels = (LabelList)await _coc.Labels.GetPlayerLabelsAsync(query);
 
             // Assert
-            Assert.IsNotNull(labels.Items);
-            Assert.AreEqual(limit, labels.Items.Count);
+            Assert.IsNotNull(labels);
+            Assert.AreEqual(limit, labels.Count);
         }
     }
 }

--- a/src/ClashOfClans.Tests/LabelsTests.cs
+++ b/src/ClashOfClans.Tests/LabelsTests.cs
@@ -1,5 +1,6 @@
 ﻿using ClashOfClans.Search;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace ClashOfClans.Tests
@@ -17,6 +18,7 @@ namespace ClashOfClans.Tests
 
             // Assert
             Assert.IsNotNull(labels.Items);
+            labels.Items.ForEach(label => Trace.WriteLine(label.Dump()));
         }
 
         [TestMethod]
@@ -47,6 +49,7 @@ namespace ClashOfClans.Tests
 
             // Assert
             Assert.IsNotNull(labels.Items);
+            labels.Items.ForEach(label => Trace.WriteLine(label.Dump()));
         }
 
         [TestMethod]

--- a/src/ClashOfClans.Tests/LabelsTests.cs
+++ b/src/ClashOfClans.Tests/LabelsTests.cs
@@ -1,0 +1,70 @@
+﻿using ClashOfClans.Search;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+
+namespace ClashOfClans.Tests
+{
+    [TestClass]
+    public class LabelsTests : TestsBase
+    {
+        [TestMethod]
+        public async Task ListClanLabels()
+        {
+            // Arrange
+
+            // Act
+            var labels = await _coc.Labels.GetClanLabelsAsync();
+
+            // Assert
+            Assert.IsNotNull(labels.Items);
+        }
+
+        [TestMethod]
+        public async Task ListClanLabelsLimit5()
+        {
+            // Arrange
+            var limit = 5;
+            var query = new Query
+            {
+                Limit = limit
+            };
+
+            // Act
+            var labels = await _coc.Labels.GetClanLabelsAsync(query);
+
+            // Assert
+            Assert.IsNotNull(labels.Items);
+            Assert.AreEqual(limit, labels.Items.Count);
+        }
+
+        [TestMethod]
+        public async Task ListPlayerLabels()
+        {
+            // Arrange
+
+            // Act
+            var labels = await _coc.Labels.GetPlayerLabelsAsync();
+
+            // Assert
+            Assert.IsNotNull(labels.Items);
+        }
+
+        [TestMethod]
+        public async Task ListPlayerLabelsLimit10()
+        {
+            // Arrange
+            var limit = 10;
+            var query = new Query
+            {
+                Limit = limit
+            };
+
+            // Act
+            var labels = await _coc.Labels.GetPlayerLabelsAsync(query);
+
+            // Assert
+            Assert.IsNotNull(labels.Items);
+            Assert.AreEqual(limit, labels.Items.Count);
+        }
+    }
+}

--- a/src/ClashOfClans.Tests/LeaguesTests.cs
+++ b/src/ClashOfClans.Tests/LeaguesTests.cs
@@ -25,7 +25,7 @@ namespace ClashOfClans.Tests
         {
             // Arrange
             var leagues = _coc.Leagues;
-            var leagueId = GetRandom(_leagues.Items).Id;
+            var leagueId = GetRandom(_leagues).Id;
 
             // Act
             var league = await leagues.GetLeagueAsync(leagueId);

--- a/src/ClashOfClans.Tests/LeaguesTests.cs
+++ b/src/ClashOfClans.Tests/LeaguesTests.cs
@@ -1,4 +1,5 @@
-﻿using ClashOfClans.Search;
+﻿using ClashOfClans.Models;
+using ClashOfClans.Search;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 
@@ -14,7 +15,7 @@ namespace ClashOfClans.Tests
             var leagues = _coc.Leagues;
 
             // Act
-            var leagueList = await leagues.GetLeaguesAsync();
+            var leagueList = (LeagueList)await leagues.GetLeaguesAsync();
 
             // Assert
             Assert.IsNotNull(leagueList);
@@ -41,7 +42,7 @@ namespace ClashOfClans.Tests
             var league = _leagues["Legend League"];
 
             // Act
-            var leagueSeasonList = await _coc.Leagues.GetLeagueSeasonsAsync(league.Id);
+            var leagueSeasonList = (LeagueSeasonList)await _coc.Leagues.GetLeagueSeasonsAsync(league.Id);
 
             // Assert
             Assert.IsNotNull(leagueSeasonList);
@@ -60,7 +61,7 @@ namespace ClashOfClans.Tests
             };
 
             // Act
-            var seasonPlayerRankingList = await _coc.Leagues.GetLeagueSeasonRankingsAsync(league.Id, season.Id, query);
+            var seasonPlayerRankingList = (PlayerRankingList)await _coc.Leagues.GetLeagueSeasonRankingsAsync(league.Id, season.Id, query);
 
             // Assert
             Assert.IsNotNull(seasonPlayerRankingList);

--- a/src/ClashOfClans.Tests/LocationsTests.cs
+++ b/src/ClashOfClans.Tests/LocationsTests.cs
@@ -50,7 +50,7 @@ namespace ClashOfClans.Tests
         public async Task GetLocationInformation()
         {
             // Arrange
-            var locationId = GetRandom(_locations.Items).Id;
+            var locationId = GetRandom(_locations).Id;
 
             // Act
             var location = await _coc.Locations.GetLocationAsync(locationId);
@@ -63,7 +63,7 @@ namespace ClashOfClans.Tests
         public async Task GetClanRankingsForASpecificLocation()
         {
             // Arrange
-            var location = GetRandom(_locations.Items, l => l.IsCountry == true);
+            var location = GetRandom(_locations, l => l.IsCountry == true);
             var query = new Query
             {
                 Limit = ItemLimit
@@ -81,25 +81,25 @@ namespace ClashOfClans.Tests
         public async Task GetPlayerRankingsForASpecificLocation()
         {
             // Arrange
-            var location = GetRandom(_locations.Items, l => l.IsCountry == true);
+            var location = GetRandom(_locations, l => l.IsCountry == true);
             var query = new Query
             {
                 Limit = ItemLimit
             };
 
             // Act
-            var playerRankingList = await _coc.Locations.GetPlayerRankingAsync(location.Id, query);
+            var playerRankingList = (await _coc.Locations.GetPlayerRankingAsync(location.Id, query)).Items;
 
             // Assert
             Assert.IsNotNull(playerRankingList);
-            Assert.IsTrue(playerRankingList.Items.Count <= ItemLimit, $"Id {location.Id}");
+            Assert.IsTrue(playerRankingList.Count <= ItemLimit, $"Id {location.Id}");
         }
 
         [TestMethod]
         public async Task GetClanVersusRankingsForASpecificLocation()
         {
             // Arrange
-            var location = GetRandom(_locations.Items, l => l.IsCountry == true);
+            var location = GetRandom(_locations, l => l.IsCountry == true);
             var query = new Query
             {
                 Limit = ItemLimit
@@ -117,7 +117,7 @@ namespace ClashOfClans.Tests
         public async Task GetPlayerVersusRankingsForASpecificLocation()
         {
             // Arrange
-            var location = GetRandom(_locations.Items, l => l.IsCountry == true);
+            var location = GetRandom(_locations, l => l.IsCountry == true);
             var query = new Query
             {
                 Limit = ItemLimit

--- a/src/ClashOfClans.Tests/LocationsTests.cs
+++ b/src/ClashOfClans.Tests/LocationsTests.cs
@@ -1,4 +1,5 @@
-﻿using ClashOfClans.Search;
+﻿using ClashOfClans.Models;
+using ClashOfClans.Search;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 
@@ -16,7 +17,7 @@ namespace ClashOfClans.Tests
             var locations = _coc.Locations;
 
             // Act
-            var locationList = await locations.GetLocationsAsync();
+            var locationList = (LocationList)await locations.GetLocationsAsync();
 
             // Assert
             Assert.IsNotNull(locationList);
@@ -70,11 +71,11 @@ namespace ClashOfClans.Tests
             };
 
             // Act
-            var clanRankingList = await _coc.Locations.GetClanRankingAsync(location.Id, query);
+            var clanRankingList = (ClanRankingList)await _coc.Locations.GetClanRankingAsync(location.Id, query);
 
             // Assert
             Assert.IsNotNull(clanRankingList);
-            Assert.AreEqual(ItemLimit, clanRankingList.Items.Count, $"Id {location.Id}");
+            Assert.AreEqual(ItemLimit, clanRankingList.Count, $"Id {location.Id}");
         }
 
         [TestMethod]
@@ -88,7 +89,7 @@ namespace ClashOfClans.Tests
             };
 
             // Act
-            var playerRankingList = (await _coc.Locations.GetPlayerRankingAsync(location.Id, query)).Items;
+            var playerRankingList = (PlayerRankingList)await _coc.Locations.GetPlayerRankingAsync(location.Id, query);
 
             // Assert
             Assert.IsNotNull(playerRankingList);
@@ -106,11 +107,11 @@ namespace ClashOfClans.Tests
             };
 
             // Act
-            var clanRankingList = await _coc.Locations.GetClanVersusRankingAsync(location.Id, query);
+            var clanRankingList = (ClanVersusRankingList)await _coc.Locations.GetClanVersusRankingAsync(location.Id, query);
 
             // Assert
             Assert.IsNotNull(clanRankingList);
-            Assert.AreEqual(ItemLimit, clanRankingList.Items.Count, $"Id {location.Id}");
+            Assert.AreEqual(ItemLimit, clanRankingList.Count, $"Id {location.Id}");
         }
 
         [TestMethod]
@@ -124,11 +125,11 @@ namespace ClashOfClans.Tests
             };
 
             // Act
-            var playerVersusRankingList = await _coc.Locations.GetPlayerVersusRankingAsync(location.Id, query);
+            var playerVersusRankingList = (PlayerVersusRankingList)await _coc.Locations.GetPlayerVersusRankingAsync(location.Id, query);
 
             // Assert
             Assert.IsNotNull(playerVersusRankingList);
-            Assert.IsTrue(playerVersusRankingList.Items.Count <= ItemLimit, $"Id {location.Id}");
+            Assert.IsTrue(playerVersusRankingList.Count <= ItemLimit, $"Id {location.Id}");
         }
     }
 }

--- a/src/ClashOfClans.Tests/TestsBase.cs
+++ b/src/ClashOfClans.Tests/TestsBase.cs
@@ -47,9 +47,9 @@ namespace ClashOfClans.Tests
                     Limit = 50
                 };
 
-                _clans = await _coc.Clans.SearchClansAsync(query);
-                _leagues = await _coc.Leagues.GetLeaguesAsync();
-                _locations = await _coc.Locations.GetLocationsAsync();
+                _clans = (await _coc.Clans.SearchClansAsync(query)).Items;
+                _leagues = (await _coc.Leagues.GetLeaguesAsync()).Items;
+                _locations = (await _coc.Locations.GetLocationsAsync()).Items;
             }
             catch (ClashOfClansException ex)
             {

--- a/src/ClashOfClans.Tests/TestsBase.cs
+++ b/src/ClashOfClans.Tests/TestsBase.cs
@@ -47,9 +47,9 @@ namespace ClashOfClans.Tests
                     Limit = 50
                 };
 
-                _clans = (await _coc.Clans.SearchClansAsync(query)).Items;
-                _leagues = (await _coc.Leagues.GetLeaguesAsync()).Items;
-                _locations = (await _coc.Locations.GetLocationsAsync()).Items;
+                _clans = (ClanList)await _coc.Clans.SearchClansAsync(query);
+                _leagues = (LeagueList)await _coc.Leagues.GetLeaguesAsync();
+                _locations = (LocationList)await _coc.Locations.GetLocationsAsync();
             }
             catch (ClashOfClansException ex)
             {

--- a/src/ClashOfClans/Api/Clans.cs
+++ b/src/ClashOfClans/Api/Clans.cs
@@ -18,13 +18,13 @@ namespace ClashOfClans.Api
         }
 
         // GET /clans
-        public async Task<ClanList> SearchClansAsync(QueryClans query)
+        public async Task<QueryResult<ClanList>> SearchClansAsync(QueryClans query)
         {
             _validator.ValidateQueryClans(query);
 
             var uri = $"clans{query}";
 
-            return await _gameData.RequestAsync<ClanList>(uri);
+            return await _gameData.RequestAsync<QueryResult<ClanList>>(uri);
         }
 
         // GET /clans/{clanTag}
@@ -38,7 +38,7 @@ namespace ClashOfClans.Api
         }
 
         // GET /clans/{clanTag}/members
-        public async Task<ClanMemberList> GetClanMembersAsync(string clanTag, Query query = null)
+        public async Task<QueryResult<ClanMemberList>> GetClanMembersAsync(string clanTag, Query query = null)
         {
             _validator
                 .ValidateClanTag(clanTag)
@@ -46,11 +46,11 @@ namespace ClashOfClans.Api
 
             var uri = $"clans/{clanTag}/members{query}";
 
-            return await _gameData.RequestAsync<ClanMemberList>(uri);
+            return await _gameData.RequestAsync<QueryResult<ClanMemberList>>(uri);
         }
 
         // GET /clans/{clanTag}/warlog
-        public async Task<ClanWarLog> GetClanWarLogAsync(string clanTag, Query query = null)
+        public async Task<QueryResult<ClanWarLog>> GetClanWarLogAsync(string clanTag, Query query = null)
         {
             _validator
                 .ValidateClanTag(clanTag)
@@ -58,7 +58,7 @@ namespace ClashOfClans.Api
 
             var uri = $"clans/{clanTag}/warlog{query}";
 
-            return await _gameData.RequestAsync<ClanWarLog>(uri);
+            return await _gameData.RequestAsync<QueryResult<ClanWarLog>>(uri);
         }
 
         // GET /clans/{clanTag}/currentwar

--- a/src/ClashOfClans/Api/Labels.cs
+++ b/src/ClashOfClans/Api/Labels.cs
@@ -1,0 +1,40 @@
+﻿using ClashOfClans.Core;
+using ClashOfClans.Models;
+using ClashOfClans.Search;
+using ClashOfClans.Validation;
+using System.Threading.Tasks;
+
+namespace ClashOfClans.Api
+{
+    internal class Labels : ILabels
+    {
+        private readonly IGameData _gameData;
+        private readonly Validator _validator;
+
+        public Labels(IGameData gameData, Validator validator)
+        {
+            _gameData = gameData;
+            _validator = validator;
+        }
+
+        // GET /labels/clans
+        public async Task<ItemList<LabelList>> GetClanLabelsAsync(Query query = null)
+        {
+            _validator.ValidateQuery(query);
+
+            var uri = $"labels/clans{query}";
+
+            return await _gameData.RequestAsync<ItemList<LabelList>>(uri);
+        }
+
+        // GET /labels/players
+        public async Task<ItemList<LabelList>> GetPlayerLabelsAsync(Query query = null)
+        {
+            _validator.ValidateQuery(query);
+
+            var uri = $"labels/players{query}";
+
+            return await _gameData.RequestAsync<ItemList<LabelList>>(uri);
+        }
+    }
+}

--- a/src/ClashOfClans/Api/Labels.cs
+++ b/src/ClashOfClans/Api/Labels.cs
@@ -18,23 +18,23 @@ namespace ClashOfClans.Api
         }
 
         // GET /labels/clans
-        public async Task<ItemList<LabelList>> GetClanLabelsAsync(Query query = null)
+        public async Task<QueryResult<LabelList>> GetClanLabelsAsync(Query query = null)
         {
             _validator.ValidateQuery(query);
 
             var uri = $"labels/clans{query}";
 
-            return await _gameData.RequestAsync<ItemList<LabelList>>(uri);
+            return await _gameData.RequestAsync<QueryResult<LabelList>>(uri);
         }
 
         // GET /labels/players
-        public async Task<ItemList<LabelList>> GetPlayerLabelsAsync(Query query = null)
+        public async Task<QueryResult<LabelList>> GetPlayerLabelsAsync(Query query = null)
         {
             _validator.ValidateQuery(query);
 
             var uri = $"labels/players{query}";
 
-            return await _gameData.RequestAsync<ItemList<LabelList>>(uri);
+            return await _gameData.RequestAsync<QueryResult<LabelList>>(uri);
         }
     }
 }

--- a/src/ClashOfClans/Api/Leagues.cs
+++ b/src/ClashOfClans/Api/Leagues.cs
@@ -18,13 +18,13 @@ namespace ClashOfClans.Api
         }
 
         // GET /leagues
-        public async Task<LeagueList> GetLeaguesAsync(Query query = null)
+        public async Task<QueryResult<LeagueList>> GetLeaguesAsync(Query query = null)
         {
             _validator.ValidateQuery(query);
 
             var uri = $"leagues{query}";
 
-            return await _gameData.RequestAsync<LeagueList>(uri);
+            return await _gameData.RequestAsync<QueryResult<LeagueList>>(uri);
         }
 
         // GET /leagues/{leagueId}
@@ -38,7 +38,7 @@ namespace ClashOfClans.Api
         }
 
         // GET /leagues/{leagueId}/seasons
-        public async Task<LeagueSeasonList> GetLeagueSeasonsAsync(int? leagueId, Query query = null)
+        public async Task<QueryResult<LeagueSeasonList>> GetLeagueSeasonsAsync(int? leagueId, Query query = null)
         {
             _validator
                 .ValidateLeagueId(leagueId)
@@ -46,11 +46,11 @@ namespace ClashOfClans.Api
 
             var uri = $"leagues/{leagueId}/seasons{query}";
 
-            return await _gameData.RequestAsync<LeagueSeasonList>(uri);
+            return await _gameData.RequestAsync<QueryResult<LeagueSeasonList>>(uri);
         }
 
         // GET /leagues/{leagueId}/seasons/{seasonId}
-        public async Task<PlayerRankingList> GetLeagueSeasonRankingsAsync(int? leagueId, string seasonId, Query query = null)
+        public async Task<QueryResult<PlayerRankingList>> GetLeagueSeasonRankingsAsync(int? leagueId, string seasonId, Query query = null)
         {
             _validator
                 .ValidateLeagueId(leagueId)
@@ -59,7 +59,7 @@ namespace ClashOfClans.Api
 
             var uri = $"leagues/{leagueId}/seasons/{seasonId}{query}";
 
-            return await _gameData.RequestAsync<PlayerRankingList>(uri);
+            return await _gameData.RequestAsync<QueryResult<PlayerRankingList>>(uri);
         }
     }
 }

--- a/src/ClashOfClans/Api/Locations.cs
+++ b/src/ClashOfClans/Api/Locations.cs
@@ -18,13 +18,13 @@ namespace ClashOfClans.Api
         }
 
         // GET /locations
-        public async Task<LocationList> GetLocationsAsync(Query query = null)
+        public async Task<QueryResult<LocationList>> GetLocationsAsync(Query query = null)
         {
             _validator.ValidateQuery(query);
 
             var uri = $"locations{query}";
 
-            return await _gameData.RequestAsync<LocationList>(uri);
+            return await _gameData.RequestAsync<QueryResult<LocationList>>(uri);
         }
 
         // GET /locations/{locationId}
@@ -38,7 +38,7 @@ namespace ClashOfClans.Api
         }
 
         // GET /locations/{locationId}/rankings/clans
-        public async Task<ClanRankingList> GetClanRankingAsync(int? locationId, Query query = null)
+        public async Task<QueryResult<ClanRankingList>> GetClanRankingAsync(int? locationId, Query query = null)
         {
             _validator
                 .ValidateLocationId(locationId)
@@ -46,11 +46,11 @@ namespace ClashOfClans.Api
 
             var uri = $"locations/{locationId}/rankings/clans{query}";
 
-            return await _gameData.RequestAsync<ClanRankingList>(uri);
+            return await _gameData.RequestAsync<QueryResult<ClanRankingList>>(uri);
         }
 
         // GET /locations/{locationId}/rankings/players
-        public async Task<PlayerRankingList> GetPlayerRankingAsync(int? locationId, Query query = null)
+        public async Task<QueryResult<PlayerRankingList>> GetPlayerRankingAsync(int? locationId, Query query = null)
         {
             _validator
                 .ValidateLocationId(locationId)
@@ -58,11 +58,11 @@ namespace ClashOfClans.Api
 
             var uri = $"locations/{locationId}/rankings/players{query}";
 
-            return await _gameData.RequestAsync<PlayerRankingList>(uri);
+            return await _gameData.RequestAsync<QueryResult<PlayerRankingList>>(uri);
         }
 
         // GET /locations/{locationId}/rankings/clans-versus
-        public async Task<ClanVersusRankingList> GetClanVersusRankingAsync(int? locationId, Query query = null)
+        public async Task<QueryResult<ClanVersusRankingList>> GetClanVersusRankingAsync(int? locationId, Query query = null)
         {
             _validator
                 .ValidateLocationId(locationId)
@@ -70,11 +70,11 @@ namespace ClashOfClans.Api
 
             var uri = $"locations/{locationId}/rankings/clans-versus{query}";
 
-            return await _gameData.RequestAsync<ClanVersusRankingList>(uri);
+            return await _gameData.RequestAsync<QueryResult<ClanVersusRankingList>>(uri);
         }
 
         // GET /locations/{locationId}/rankings/players-versus
-        public async Task<PlayerVersusRankingList> GetPlayerVersusRankingAsync(int? locationId, Query query = null)
+        public async Task<QueryResult<PlayerVersusRankingList>> GetPlayerVersusRankingAsync(int? locationId, Query query = null)
         {
             _validator
                 .ValidateLocationId(locationId)
@@ -82,7 +82,7 @@ namespace ClashOfClans.Api
 
             var uri = $"locations/{locationId}/rankings/players-versus{query}";
 
-            return await _gameData.RequestAsync<PlayerVersusRankingList>(uri);
+            return await _gameData.RequestAsync<QueryResult<PlayerVersusRankingList>>(uri);
         }
     }
 }

--- a/src/ClashOfClans/ClashOfClans.csproj
+++ b/src/ClashOfClans/ClashOfClans.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/ClashOfClans/ClashOfClansApi.cs
+++ b/src/ClashOfClans/ClashOfClansApi.cs
@@ -29,6 +29,8 @@ namespace ClashOfClans
             Locations = new Locations(gameData, validator);
             Leagues = new Leagues(gameData, validator);
             Players = new Players(gameData, validator);
+            Labels = new Labels(gameData, validator);
+
         }
 
         /// <summary>
@@ -66,5 +68,7 @@ namespace ClashOfClans
         /// Access player specific information
         /// </summary>
         public IPlayers Players { get; }
+
+        public ILabels Labels { get; }
     }
 }

--- a/src/ClashOfClans/ClashOfClansApi.cs
+++ b/src/ClashOfClans/ClashOfClansApi.cs
@@ -30,7 +30,6 @@ namespace ClashOfClans
             Leagues = new Leagues(gameData, validator);
             Players = new Players(gameData, validator);
             Labels = new Labels(gameData, validator);
-
         }
 
         /// <summary>

--- a/src/ClashOfClans/ClashOfClansApi.cs
+++ b/src/ClashOfClans/ClashOfClansApi.cs
@@ -68,6 +68,9 @@ namespace ClashOfClans
         /// </summary>
         public IPlayers Players { get; }
 
+        /// <summary>
+        /// Access labels
+        /// </summary>
         public ILabels Labels { get; }
     }
 }

--- a/src/ClashOfClans/IClans.cs
+++ b/src/ClashOfClans/IClans.cs
@@ -16,7 +16,7 @@ namespace ClashOfClans
         /// <exception cref="Core.ClashOfClansException">Communication error with the backend API</exception>
         /// <exception cref="System.ArgumentException">Argument is invalid</exception>
         /// <returns>Clan(s) that match the query criteria</returns>
-        Task<ClanList> SearchClansAsync(QueryClans query);
+        Task<QueryResult<ClanList>> SearchClansAsync(QueryClans query);
 
         /// <summary>
         /// Get clan information
@@ -35,7 +35,7 @@ namespace ClashOfClans
         /// <exception cref="Core.ClashOfClansException">Communication error with the backend API</exception>
         /// <exception cref="System.ArgumentException">Argument is invalid</exception>
         /// <returns>List of clan members</returns>
-        Task<ClanMemberList> GetClanMembersAsync(string clanTag, Query query = null);
+        Task<QueryResult<ClanMemberList>> GetClanMembersAsync(string clanTag, Query query = null);
 
         /// <summary>
         /// Retrieve clan's clan war log
@@ -45,7 +45,7 @@ namespace ClashOfClans
         /// <exception cref="Core.ClashOfClansException">Communication error with the backend API</exception>
         /// <exception cref="System.ArgumentException">Argument is invalid</exception>
         /// <returns>Clan's clan war log</returns>
-        Task<ClanWarLog> GetClanWarLogAsync(string clanTag, Query query = null);
+        Task<QueryResult<ClanWarLog>> GetClanWarLogAsync(string clanTag, Query query = null);
 
         /// <summary>
         /// Retrieve information about clan's current clan war

--- a/src/ClashOfClans/ILabels.cs
+++ b/src/ClashOfClans/ILabels.cs
@@ -1,0 +1,12 @@
+﻿using ClashOfClans.Models;
+using ClashOfClans.Search;
+using System.Threading.Tasks;
+
+namespace ClashOfClans
+{
+    public interface ILabels
+    {
+        Task<ItemList<LabelList>> GetClanLabelsAsync(Query query = null);
+        Task<ItemList<LabelList>> GetPlayerLabelsAsync(Query query = null);
+    }
+}

--- a/src/ClashOfClans/ILabels.cs
+++ b/src/ClashOfClans/ILabels.cs
@@ -6,7 +6,8 @@ namespace ClashOfClans
 {
     public interface ILabels
     {
-        Task<ItemList<LabelList>> GetClanLabelsAsync(Query query = null);
-        Task<ItemList<LabelList>> GetPlayerLabelsAsync(Query query = null);
+        Task<QueryResult<LabelList>> GetClanLabelsAsync(Query query = null);
+
+        Task<QueryResult<LabelList>> GetPlayerLabelsAsync(Query query = null);
     }
 }

--- a/src/ClashOfClans/ILabels.cs
+++ b/src/ClashOfClans/ILabels.cs
@@ -6,8 +6,18 @@ namespace ClashOfClans
 {
     public interface ILabels
     {
+        /// <summary>
+        /// List clan labels
+        /// </summary>
+        /// <param name="query">Query parameters</param>
+        /// <returns>Clan label list</returns>
         Task<QueryResult<LabelList>> GetClanLabelsAsync(Query query = null);
 
+        /// <summary>
+        /// List player labels
+        /// </summary>
+        /// <param name="query">Query parameters</param>
+        /// <returns>Player label list</returns>
         Task<QueryResult<LabelList>> GetPlayerLabelsAsync(Query query = null);
     }
 }

--- a/src/ClashOfClans/ILeagues.cs
+++ b/src/ClashOfClans/ILeagues.cs
@@ -16,7 +16,7 @@ namespace ClashOfClans
         /// <exception cref="Core.ClashOfClansException">Communication error with the backend API</exception>
         /// <exception cref="System.ArgumentException">Argument is invalid</exception>
         /// <returns>League list</returns>
-        Task<LeagueList> GetLeaguesAsync(Query query = null);
+        Task<QueryResult<LeagueList>> GetLeaguesAsync(Query query = null);
 
         /// <summary>
         /// Get league information
@@ -35,7 +35,7 @@ namespace ClashOfClans
         /// <exception cref="Core.ClashOfClansException">Communication error with the backend API</exception>
         /// <exception cref="System.ArgumentException">Argument is invalid</exception>
         /// <returns>League season list</returns>
-        Task<LeagueSeasonList> GetLeagueSeasonsAsync(int? leagueId, Query query = null);
+        Task<QueryResult<LeagueSeasonList>> GetLeagueSeasonsAsync(int? leagueId, Query query = null);
 
         /// <summary>
         /// Get league season rankings. Note that league season information is available only for Legend League.
@@ -46,6 +46,6 @@ namespace ClashOfClans
         /// <exception cref="Core.ClashOfClansException">Communication error with the backend API</exception>
         /// <exception cref="System.ArgumentException">Argument is invalid</exception>
         /// <returns>Season player ranking list</returns>
-        Task<PlayerRankingList> GetLeagueSeasonRankingsAsync(int? leagueId, string seasonId, Query query = null);
+        Task<QueryResult<PlayerRankingList>> GetLeagueSeasonRankingsAsync(int? leagueId, string seasonId, Query query = null);
     }
 }

--- a/src/ClashOfClans/ILocations.cs
+++ b/src/ClashOfClans/ILocations.cs
@@ -16,7 +16,7 @@ namespace ClashOfClans
         /// <exception cref="Core.ClashOfClansException">Communication error with the backend API</exception>
         /// <exception cref="System.ArgumentException">Argument is invalid</exception>
         /// <returns>Location list</returns>
-        Task<LocationList> GetLocationsAsync(Query query = null);
+        Task<QueryResult<LocationList>> GetLocationsAsync(Query query = null);
 
         /// <summary>
         /// Get location information
@@ -35,7 +35,7 @@ namespace ClashOfClans
         /// <exception cref="Core.ClashOfClansException">Communication error with the backend API</exception>
         /// <exception cref="System.ArgumentException">Argument is invalid</exception>
         /// <returns>Clan ranking list</returns>
-        Task<ClanRankingList> GetClanRankingAsync(int? locationId, Query query = null);
+        Task<QueryResult<ClanRankingList>> GetClanRankingAsync(int? locationId, Query query = null);
 
         /// <summary>
         /// Get player rankings for a specific location
@@ -45,7 +45,7 @@ namespace ClashOfClans
         /// <exception cref="Core.ClashOfClansException">Communication error with the backend API</exception>
         /// <exception cref="System.ArgumentException">Argument is invalid</exception>
         /// <returns>Player ranking list</returns>
-        Task<PlayerRankingList> GetPlayerRankingAsync(int? locationId, Query query = null);
+        Task<QueryResult<PlayerRankingList>> GetPlayerRankingAsync(int? locationId, Query query = null);
 
         /// <summary>
         /// Get clan versus rankings for a specific location
@@ -55,7 +55,7 @@ namespace ClashOfClans
         /// <exception cref="Core.ClashOfClansException">Communication error with the backend API</exception>
         /// <exception cref="System.ArgumentException">Argument is invalid</exception>
         /// <returns>Clan ranking list</returns>
-        Task<ClanVersusRankingList> GetClanVersusRankingAsync(int? locationId, Query query = null);
+        Task<QueryResult<ClanVersusRankingList>> GetClanVersusRankingAsync(int? locationId, Query query = null);
 
         /// <summary>
         /// Get player versus rankings for a specific location
@@ -65,6 +65,6 @@ namespace ClashOfClans
         /// <exception cref="Core.ClashOfClansException">Communication error with the backend API</exception>
         /// <exception cref="System.ArgumentException">Argument is invalid</exception>
         /// <returns>Player versus ranking list</returns>
-        Task<PlayerVersusRankingList> GetPlayerVersusRankingAsync(int? locationId, Query query = null);
+        Task<QueryResult<PlayerVersusRankingList>> GetPlayerVersusRankingAsync(int? locationId, Query query = null);
     }
 }

--- a/src/ClashOfClans/Models/ClanList.cs
+++ b/src/ClashOfClans/Models/ClanList.cs
@@ -2,8 +2,7 @@
 
 namespace ClashOfClans.Models
 {
-    public class ClanList : Queryable
+    public class ClanList : List<Clan>
     {
-        public List<Clan> Items { get; set; }
     }
 }

--- a/src/ClashOfClans/Models/ClanMemberList.cs
+++ b/src/ClashOfClans/Models/ClanMemberList.cs
@@ -2,8 +2,7 @@
 
 namespace ClashOfClans.Models
 {
-    public class ClanMemberList : Queryable
+    public class ClanMemberList : List<ClanMember>
     {
-        public List<ClanMember> Items { get; set; }
     }
 }

--- a/src/ClashOfClans/Models/ClanRankingList.cs
+++ b/src/ClashOfClans/Models/ClanRankingList.cs
@@ -2,8 +2,7 @@
 
 namespace ClashOfClans.Models
 {
-    public class ClanRankingList : Queryable
+    public class ClanRankingList : List<ClanRanking>
     {
-        public List<ClanRanking> Items { get; set; }
     }
 }

--- a/src/ClashOfClans/Models/ClanVersusRankingList.cs
+++ b/src/ClashOfClans/Models/ClanVersusRankingList.cs
@@ -2,8 +2,7 @@
 
 namespace ClashOfClans.Models
 {
-    public class ClanVersusRankingList : Queryable
+    public class ClanVersusRankingList : List<ClanVersusRanking>
     {
-        public List<ClanVersusRanking> Items { get; set; }
     }
 }

--- a/src/ClashOfClans/Models/ClanWarLog.cs
+++ b/src/ClashOfClans/Models/ClanWarLog.cs
@@ -2,8 +2,7 @@
 
 namespace ClashOfClans.Models
 {
-    public class ClanWarLog : Queryable
+    public class ClanWarLog : List<ClanWarLogEntry>
     {
-        public List<ClanWarLogEntry> Items { get; set; }
     }
 }

--- a/src/ClashOfClans/Models/ItemList.cs
+++ b/src/ClashOfClans/Models/ItemList.cs
@@ -1,0 +1,7 @@
+﻿namespace ClashOfClans.Models
+{
+    public class ItemList<T> : Queryable
+    {
+        public T Items { get; set; }
+    }
+}

--- a/src/ClashOfClans/Models/ItemList.cs
+++ b/src/ClashOfClans/Models/ItemList.cs
@@ -1,7 +1,0 @@
-﻿namespace ClashOfClans.Models
-{
-    public class ItemList<T> : Queryable
-    {
-        public T Items { get; set; }
-    }
-}

--- a/src/ClashOfClans/Models/LeagueList.cs
+++ b/src/ClashOfClans/Models/LeagueList.cs
@@ -2,8 +2,7 @@
 
 namespace ClashOfClans.Models
 {
-    public partial class LeagueList : Queryable
+    public partial class LeagueList : List<League>
     {
-        public List<League> Items { get; set; }
     }
 }

--- a/src/ClashOfClans/Models/LeagueSeasonList.cs
+++ b/src/ClashOfClans/Models/LeagueSeasonList.cs
@@ -2,8 +2,7 @@
 
 namespace ClashOfClans.Models
 {
-    public class LeagueSeasonList : Queryable
+    public class LeagueSeasonList : List<LeagueSeason>
     {
-        public List<LeagueSeason> Items { get; set; }
     }
 }

--- a/src/ClashOfClans/Models/LocationList.cs
+++ b/src/ClashOfClans/Models/LocationList.cs
@@ -2,8 +2,7 @@
 
 namespace ClashOfClans.Models
 {
-    public partial class LocationList : Queryable
+    public partial class LocationList : List<Location>
     {
-        public List<Location> Items { get; set; }
     }
 }

--- a/src/ClashOfClans/Models/PlayerRankingList.cs
+++ b/src/ClashOfClans/Models/PlayerRankingList.cs
@@ -2,8 +2,7 @@
 
 namespace ClashOfClans.Models
 {
-    public class PlayerRankingList : Queryable
+    public class PlayerRankingList : List<PlayerRanking>
     {
-        public List<PlayerRanking> Items { get; set; }
     }
 }

--- a/src/ClashOfClans/Models/PlayerVersusRankingList.cs
+++ b/src/ClashOfClans/Models/PlayerVersusRankingList.cs
@@ -2,8 +2,7 @@
 
 namespace ClashOfClans.Models
 {
-    public class PlayerVersusRankingList : Queryable
+    public class PlayerVersusRankingList : List<PlayerVersusRanking>
     {
-        public List<PlayerVersusRanking> Items { get; set; }
     }
 }

--- a/src/ClashOfClans/Models/QueryResult.cs
+++ b/src/ClashOfClans/Models/QueryResult.cs
@@ -1,0 +1,13 @@
+﻿namespace ClashOfClans.Models
+{
+    /// <summary>
+    /// A class representing a query result.
+    /// </summary>
+    /// <typeparam name="T">The type of the result items</typeparam>
+    public class QueryResult<T>
+    {
+        public T Items { get; set; }
+
+        public Paging Paging { get; set; }
+    }
+}

--- a/src/ClashOfClans/Models/QueryResult.cs
+++ b/src/ClashOfClans/Models/QueryResult.cs
@@ -4,7 +4,7 @@
     /// A class representing a query result.
     /// </summary>
     /// <typeparam name="T">The type of the result items</typeparam>
-    public class QueryResult<T>
+    public class QueryResult<T> where T : class
     {
         public T Items { get; set; }
 

--- a/src/ClashOfClans/Models/Queryable.cs
+++ b/src/ClashOfClans/Models/Queryable.cs
@@ -1,7 +1,0 @@
-﻿namespace ClashOfClans.Models
-{
-    public class Queryable
-    {
-        public Paging Paging { get; set; }
-    }
-}

--- a/src/ClashOfClans/Models/Utilities/LeagueList.cs
+++ b/src/ClashOfClans/Models/Utilities/LeagueList.cs
@@ -18,7 +18,7 @@ namespace ClashOfClans.Models
         /// <returns>League data</returns>
         public League this[string name]
         {
-            get => Items?.SingleOrDefault(l => l.Name == name);
+            get => this.SingleOrDefault(l => l.Name == name);
         }
     }
 }

--- a/src/ClashOfClans/Models/Utilities/LeagueList.cs
+++ b/src/ClashOfClans/Models/Utilities/LeagueList.cs
@@ -11,7 +11,7 @@ namespace ClashOfClans.Models
         /// <example>
         /// <code>
         /// var coc = new ClashOfClansApi(token);
-        /// var leagues = await coc.Leagues.GetAsync();
+        /// var leagues = (LeagueList)await coc.Leagues.GetLeaguesAsync();
         /// var league = leagues["Legend League"];
         /// </code>
         /// </example>

--- a/src/ClashOfClans/Models/Utilities/LocationList.cs
+++ b/src/ClashOfClans/Models/Utilities/LocationList.cs
@@ -11,7 +11,7 @@ namespace ClashOfClans.Models
         /// <example>
         /// <code>
         /// var coc = new ClashOfClansApi(token);
-        /// var locations = await coc.Locations.GetAsync();
+        /// var locations = (LocationList)await coc.Locations.GetLocationsAsync();
         /// var location = locations["Finland"];
         /// </code>
         /// </example>

--- a/src/ClashOfClans/Models/Utilities/LocationList.cs
+++ b/src/ClashOfClans/Models/Utilities/LocationList.cs
@@ -18,7 +18,7 @@ namespace ClashOfClans.Models
         /// <returns>Location data</returns>
         public Location this[string name]
         {
-            get => Items?.SingleOrDefault(l => l.Name == name);
+            get => this.SingleOrDefault(l => l.Name == name);
         }
     }
 }

--- a/src/ClashOfClans/Search/QueryClans.cs
+++ b/src/ClashOfClans/Search/QueryClans.cs
@@ -42,5 +42,10 @@ namespace ClashOfClans.Search
         /// Filter by minimum clan level.
         /// </summary>
         public int? MinClanLevel { get; set; }
+
+        /// <summary>
+        /// Comma separated list of label IDs to use for filtering results.
+        /// </summary>
+        public string LabelIds { get; set; }
     }
 }

--- a/src/ClashOfClans/Search/QueryResult.cs
+++ b/src/ClashOfClans/Search/QueryResult.cs
@@ -1,4 +1,6 @@
-﻿namespace ClashOfClans.Models
+﻿using ClashOfClans.Models;
+
+namespace ClashOfClans.Search
 {
     /// <summary>
     /// A class representing a query result.

--- a/src/ClashOfClans/Search/QueryResult.cs
+++ b/src/ClashOfClans/Search/QueryResult.cs
@@ -11,5 +11,11 @@ namespace ClashOfClans.Search
         public T Items { get; set; }
 
         public Paging Paging { get; set; }
+
+        /// <summary>
+        /// Allow explicit conversion from <see cref="QueryResult{T}"/> to T. The reason this is explicit
+        /// is that <see cref="Paging"/> information is lost during the conversion.
+        /// </summary>
+        public static explicit operator T(QueryResult<T> queryResult) => queryResult.Items;
     }
 }


### PR DESCRIPTION
This PR will add support for new Labels API and LabelIds for clans query.

In the scope of this PR all queries that return paging information will be put inside `QueryResult<T>` class. This change is mandatory to keep SC models in sync with the library models. However to help API users to get the proper type of element from API call (instead of `QueryResult<T>`) there is an explicit cast operator that allows to cast `QueryResult<T>` to correct return type, examples of this are available in the `ClashOfClans.App` project.