### PR TITLE
Add methods for paging

### DIFF
--- a/src/ClashOfClans.Tests.Integration/ClansTests.cs
+++ b/src/ClashOfClans.Tests.Integration/ClansTests.cs
@@ -24,7 +24,7 @@ namespace ClashOfClans.Tests.Integration
 
             // Act / Assert
             await _coc.Clans.SearchClansAsync(query);
-            Assert.IsFalse(query.MoveToPreviousItems());
+            Assert.IsFalse(query.MoveToPreviousItems(), "After initial query there should be no previous items!");
             Assert.IsTrue(query.MoveToNextItems());
 
             await _coc.Clans.SearchClansAsync(query);

--- a/src/ClashOfClans.Tests.Integration/ClansTests.cs
+++ b/src/ClashOfClans.Tests.Integration/ClansTests.cs
@@ -13,6 +13,26 @@ namespace ClashOfClans.Tests.Integration
     public class ClansTests : TestsBase
     {
         [TestMethod]
+        public async Task MovePagingMarkers()
+        {
+            // Arrange
+            var query = new QueryClans
+            {
+                MinMembers = 40,
+                Limit = 1
+            };
+
+            // Act / Assert
+            await _coc.Clans.SearchClansAsync(query);
+            Assert.IsFalse(query.MoveToPreviousItems());
+            Assert.IsTrue(query.MoveToNextItems());
+
+            await _coc.Clans.SearchClansAsync(query);
+            Assert.IsTrue(query.MoveToPreviousItems());
+            Assert.IsTrue(query.MoveToNextItems());
+        }
+
+        [TestMethod]
         public async Task SearchClans()
         {
             // Arrange
@@ -51,16 +71,16 @@ namespace ClashOfClans.Tests.Integration
             // Act
             do
             {
-                var searchResult = await _coc.Clans.SearchClansAsync(query);
-                searchResult.Items.ToList().ForEach(clan =>
+                var clans = (ClanList)await _coc.Clans.SearchClansAsync(query);
+
+                foreach (var clan in clans)
                 {
                     Assert.AreEqual(locationName, clan.Location.Name);
                     Trace.WriteLine(clan.Dump());
-                });
+                }
 
-                query.After = searchResult.Paging.Cursors.After;
-                count += searchResult.Items.Count;
-            } while (query.After != null);
+                count += clans.Count;
+            } while (query.MoveToNextItems());
 
             // Assert
             Trace.WriteLine($"{locationName}: {count}");

--- a/src/ClashOfClans.Tests.Unit/QueryTests.cs
+++ b/src/ClashOfClans.Tests.Unit/QueryTests.cs
@@ -8,6 +8,23 @@ namespace ClashOfClans.Tests.Unit
     public class QueryTests
     {
         [TestMethod]
+        public void QueryMarkerMoveToEmptyCursors()
+        {
+            // Arrange
+            var query = new Query
+            {
+            };
+
+            // Act
+            var prev = query.MoveToPreviousItems();
+            var next = query.MoveToNextItems();
+
+            // Assert
+            Assert.IsFalse(prev, "Empty markers should not allow move!");
+            Assert.IsFalse(next, "Empty markers should not allow move!");
+        }
+
+        [TestMethod]
         public void QueryLimitSetTo10()
         {
             // Arrange

--- a/src/ClashOfClans/Search/Query.cs
+++ b/src/ClashOfClans/Search/Query.cs
@@ -22,5 +22,34 @@ namespace ClashOfClans.Search
         /// only <see cref="After"/> or <see cref="Before"/> can be specified for a request, not both.
         /// </summary>
         public string Before { get; set; }
+
+        /// <summary>
+        /// Moves the <see cref="After"/> marker to next group of items
+        /// </summary>
+        /// <returns>true if there are next items, false if there are no next items</returns>
+        public bool MoveToNextItems() => SetMarkers(after: _cursors?.After);
+
+        /// <summary>
+        /// Moves the <see cref="Before"/> marker to previous group of items
+        /// </summary>
+        /// <returns>true if there are previous items, false if there are no previous items</returns>
+        public bool MoveToPreviousItems() => SetMarkers(before: _cursors?.Before);
+
+        private Cursors _cursors;
+
+        internal void SetCursors(Cursors cursors) => _cursors = cursors;
+
+        private bool SetMarkers(string before = null, string after = null)
+        {
+            Before = before;
+            After = after;
+
+            if (Before != null || After != null)
+            {
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/ClashOfClans/Search/Query.cs
+++ b/src/ClashOfClans/Search/Query.cs
@@ -24,13 +24,15 @@ namespace ClashOfClans.Search
         public string Before { get; set; }
 
         /// <summary>
-        /// Moves the <see cref="After"/> marker to next group of items
+        /// Moves the <see cref="After"/> marker to next group of items. After successful move the
+        /// client can repeat the previous API query to get next items.
         /// </summary>
         /// <returns>true if there are next items, false if there are no next items</returns>
         public bool MoveToNextItems() => SetMarkers(after: _cursors?.After);
 
         /// <summary>
-        /// Moves the <see cref="Before"/> marker to previous group of items
+        /// Moves the <see cref="Before"/> marker to previous group of items. After successful move
+        /// the client can repeat the previous API query to get previous items.
         /// </summary>
         /// <returns>true if there are previous items, false if there are no previous items</returns>
         public bool MoveToPreviousItems() => SetMarkers(before: _cursors?.Before);


### PR DESCRIPTION
This is a PR for #26 and adds needed methods to automatically perform paging tasks so that client can just repeat the previous query without needing to worry about setting the paging cursors.

Code example about how to use paging:
```
            var query = new QueryClans
            {
                Limit = 200,
                ...
            };

            do
            {
                var clans = (ClanList)await _coc.Clans.SearchClansAsync(query);
                ...
            } while (query.MoveToNextItems());
```
Same works for moving backwards by using the method `MoveToPreviousItems`. So the idea is that the client is no longer responsible for setting the paging cursor properties manually instead the client can use methods that will automatically set properties and the return value of the method indicates whether setting the cursors succeeded or not i.e. whether there are more results or not.