### PR TITLE
Change value types to non-nullable and nullable types

### DIFF
--- a/build/version.txt
+++ b/build/version.txt
@@ -6,4 +6,4 @@
 #   Patch: Backwards compatible bug fixes only
 #   -Suffix (optional): a hyphen followed by a string denoting a pre-release version (rc1, rc2, etc.)
 
-7.1.0
+8.0.0-rc1

--- a/src/ClashOfClans.Models/Clan.cs
+++ b/src/ClashOfClans.Models/Clan.cs
@@ -4,11 +4,22 @@ namespace ClashOfClans.Models
 {
     public class Clan : Identity
     {
+        private Type? _type;
+        private int? _clanLevel;
+        private int? _clanPoints;
+        private int? _clanVersusPoints;
+        private int? _requiredTrophies;
+        private WarFrequency? _warFrequency;
+        private int? _warWinStreak;
+        private int? _warWins;
+        private bool? _isWarLogPublic;
+        private int? _members;
+
         public string? Description { get; set; }
 
         public List<ClanMember>? MemberList { get; set; }
 
-        public Type? Type { get; set; }
+        public Type Type { get => _type ?? default; set => _type = value; }
 
         /// <summary>
         /// Clan location
@@ -17,31 +28,31 @@ namespace ClashOfClans.Models
 
         public UrlContainer BadgeUrls { get; set; } = default!;
 
-        public int? ClanLevel { get; set; }
+        public int ClanLevel { get => _clanLevel ?? default; set => _clanLevel = value; }
 
-        public int? ClanPoints { get; set; }
+        public int ClanPoints { get => _clanPoints ?? default; set => _clanPoints = value; }
 
-        public int? ClanVersusPoints { get; set; }
+        public int ClanVersusPoints { get => _clanVersusPoints ?? default; set => _clanVersusPoints = value; }
 
         /// <summary>
         /// Minimum trophies to join
         /// </summary>
-        public int? RequiredTrophies { get; set; }
+        public int RequiredTrophies { get => _requiredTrophies ?? default; set => _requiredTrophies = value; }
 
-        public WarFrequency? WarFrequency { get; set; }
+        public WarFrequency WarFrequency { get => _warFrequency ?? default; set => _warFrequency = value; }
 
-        public int? WarWinStreak { get; set; }
+        public int WarWinStreak { get => _warWinStreak ?? default; set => _warWinStreak = value; }
 
         /// <summary>
         /// Wars won
         /// </summary>
-        public int? WarWins { get; set; }
+        public int WarWins { get => _warWins ?? default; set => _warWins = value; }
 
-        public bool? IsWarLogPublic { get; set; }
+        public bool IsWarLogPublic { get => _isWarLogPublic ?? default; set => _isWarLogPublic = value; }
 
         public WarLeague WarLeague { get; set; } = default!;
 
-        public int? Members { get; set; }
+        public int Members { get => _members ?? default; set => _members = value; }
 
         public int? WarTies { get; set; }
 

--- a/src/ClashOfClans.Models/ClanMember.cs
+++ b/src/ClashOfClans.Models/ClanMember.cs
@@ -2,22 +2,31 @@
 {
     public class ClanMember : Identity
     {
-        public Role? Role { get; set; }
+        private Role? _role;
+        private int? _expLevel;
+        private int? _trophies;
+        private int? _versusTrophies;
+        private int? _clanRank;
+        private int? _previousClanRank;
+        private int? _donations;
+        private int? _donationsReceived;
 
-        public int? ExpLevel { get; set; }
+        public Role Role { get => _role ?? default; set => _role = value; }
+
+        public int ExpLevel { get => _expLevel ?? default; set => _expLevel = value; }
 
         public League League { get; set; } = default!;
 
-        public int? Trophies { get; set; }
+        public int Trophies { get => _trophies ?? default; set => _trophies = value; }
 
-        public int? VersusTrophies { get; set; }
+        public int VersusTrophies { get => _versusTrophies ?? default; set => _versusTrophies = value; }
 
-        public int? ClanRank { get; set; }
+        public int ClanRank { get => _clanRank ?? default; set => _clanRank = value; }
 
-        public int? PreviousClanRank { get; set; }
+        public int PreviousClanRank { get => _previousClanRank ?? default; set => _previousClanRank = value; }
 
-        public int? Donations { get; set; }
+        public int Donations { get => _donations ?? default; set => _donations = value; }
 
-        public int? DonationsReceived { get; set; }
+        public int DonationsReceived { get => _donationsReceived ?? default; set => _donationsReceived = value; }
     }
 }

--- a/src/ClashOfClans.Models/ClanRanking.cs
+++ b/src/ClashOfClans.Models/ClanRanking.cs
@@ -2,18 +2,24 @@
 {
     public class ClanRanking : Identity
     {
+        private int? _clanLevel;
+        private int? _members;
+        private int? _clanPoints;
+        private int? _rank;
+        private int? _previousRank;
+
         public Location Location { get; set; } = default!;
 
         public UrlContainer BadgeUrls { get; set; } = default!;
 
-        public int? ClanLevel { get; set; }
+        public int ClanLevel { get => _clanLevel ?? default; set => _clanLevel = value; }
 
-        public int? Members { get; set; }
+        public int Members { get => _members ?? default; set => _members = value; }
 
-        public int? ClanPoints { get; set; }
+        public int ClanPoints { get => _clanPoints ?? default; set => _clanPoints = value; }
 
-        public int? Rank { get; set; }
+        public int Rank { get => _rank ?? default; set => _rank = value; }
 
-        public int? PreviousRank { get; set; }
+        public int PreviousRank { get => _previousRank ?? default; set => _previousRank = value; }
     }
 }

--- a/src/ClashOfClans.Models/ClanVersusRanking.cs
+++ b/src/ClashOfClans.Models/ClanVersusRanking.cs
@@ -2,20 +2,26 @@
 {
     public class ClanVersusRanking : Identity
     {
+        private int? _clanLevel;
+        private int? _members;
+        private int? _rank;
+        private int? _previousRank;
+        private int? _clanVersusPoints;
+
         public Location Location { get; set; } = default!;
 
         public UrlContainer BadgeUrls { get; set; } = default!;
 
-        public int? ClanLevel { get; set; }
+        public int ClanLevel { get => _clanLevel ?? default; set => _clanLevel = value; }
 
-        public int? Members { get; set; }
+        public int Members { get => _members ?? default; set => _members = value; }
 
         public int? ClanPoints { get; set; }
 
-        public int? Rank { get; set; }
+        public int Rank { get => _rank ?? default; set => _rank = value; }
 
-        public int? PreviousRank { get; set; }
+        public int PreviousRank { get => _previousRank ?? default; set => _previousRank = value; }
 
-        public int? ClanVersusPoints { get; set; }
+        public int ClanVersusPoints { get => _clanVersusPoints ?? default; set => _clanVersusPoints = value; }
     }
 }

--- a/src/ClashOfClans.Models/ClanWarAttack.cs
+++ b/src/ClashOfClans.Models/ClanWarAttack.cs
@@ -2,14 +2,18 @@
 {
     public class ClanWarAttack
     {
+        private int? _stars;
+        private int? _destructionPercentage;
+        private int? _order;
+
         public string AttackerTag { get; set; } = default!;
 
         public string DefenderTag { get; set; } = default!;
 
-        public int? Stars { get; set; }
+        public int Stars { get => _stars ?? default; set => _stars = value; }
 
-        public int? DestructionPercentage { get; set; }
+        public int DestructionPercentage { get => _destructionPercentage ?? default; set => _destructionPercentage = value; }
 
-        public int? Order { get; set; }
+        public int Order { get => _order ?? default; set => _order = value; }
     }
 }

--- a/src/ClashOfClans.Models/ClanWarLeagueClan.cs
+++ b/src/ClashOfClans.Models/ClanWarLeagueClan.cs
@@ -2,7 +2,9 @@
 {
     public class ClanWarLeagueClan : Identity
     {
-        public int? ClanLevel { get; set; }
+        private int? clanLevel;
+
+        public int ClanLevel { get => clanLevel ?? default; set => clanLevel = value; }
 
         public UrlContainer BadgeUrls { get; set; } = default!;
 

--- a/src/ClashOfClans.Models/ClanWarLeagueClan.cs
+++ b/src/ClashOfClans.Models/ClanWarLeagueClan.cs
@@ -2,9 +2,9 @@
 {
     public class ClanWarLeagueClan : Identity
     {
-        private int? clanLevel;
+        private int? _clanLevel;
 
-        public int ClanLevel { get => clanLevel ?? default; set => clanLevel = value; }
+        public int ClanLevel { get => _clanLevel ?? default; set => _clanLevel = value; }
 
         public UrlContainer BadgeUrls { get; set; } = default!;
 

--- a/src/ClashOfClans.Models/ClanWarLeagueClanMember.cs
+++ b/src/ClashOfClans.Models/ClanWarLeagueClanMember.cs
@@ -2,8 +2,8 @@
 {
     public class ClanWarLeagueClanMember : Identity
     {
-        private int? townHallLevel;
+        private int? _townHallLevel;
 
-        public int TownHallLevel { get => townHallLevel ?? default; set => townHallLevel = value; }
+        public int TownHallLevel { get => _townHallLevel ?? default; set => _townHallLevel = value; }
     }
 }

--- a/src/ClashOfClans.Models/ClanWarLeagueClanMember.cs
+++ b/src/ClashOfClans.Models/ClanWarLeagueClanMember.cs
@@ -2,6 +2,8 @@
 {
     public class ClanWarLeagueClanMember : Identity
     {
-        public int? TownHallLevel { get; set; }
+        private int? townHallLevel;
+
+        public int TownHallLevel { get => townHallLevel ?? default; set => townHallLevel = value; }
     }
 }

--- a/src/ClashOfClans.Models/ClanWarLeagueGroup.cs
+++ b/src/ClashOfClans.Models/ClanWarLeagueGroup.cs
@@ -2,7 +2,9 @@
 {
     public class ClanWarLeagueGroup
     {
-        public State? State { get; set; }
+        private State? _state;
+
+        public State State { get => _state ?? default; set => _state = value; }
 
         public string Season { get; set; } = default!;
 

--- a/src/ClashOfClans.Models/ClanWarLeagueWar.cs
+++ b/src/ClashOfClans.Models/ClanWarLeagueWar.cs
@@ -4,10 +4,12 @@ namespace ClashOfClans.Models
 {
     public class ClanWarLeagueWar : WarBase
     {
+        private DateTime? _warStartTime;
+
         public ClanWarLeagueWarClan Clan { get; set; } = default!;
 
         public ClanWarLeagueWarClan Opponent { get; set; } = default!;
 
-        public DateTime WarStartTime { get; set; }
+        public DateTime WarStartTime { get => _warStartTime ?? default; set => _warStartTime = value; }
     }
 }

--- a/src/ClashOfClans.Models/ClanWarLeagueWarClan.cs
+++ b/src/ClashOfClans.Models/ClanWarLeagueWarClan.cs
@@ -4,15 +4,20 @@ namespace ClashOfClans.Models
 {
     public class ClanWarLeagueWarClan : Identity
     {
+        private int? _clanLevel;
+        private int? _attacks;
+        private int? _stars;
+        private float? _destructionPercentage;
+
         public UrlContainer BadgeUrls { get; set; } = default!;
 
-        public int? ClanLevel { get; set; }
+        public int ClanLevel { get => _clanLevel ?? default; set => _clanLevel = value; }
 
-        public int? Attacks { get; set; }
+        public int Attacks { get => _attacks ?? default; set => _attacks = value; }
 
-        public int? Stars { get; set; }
+        public int Stars { get => _stars ?? default; set => _stars = value; }
 
-        public float? DestructionPercentage { get; set; }
+        public float DestructionPercentage { get => _destructionPercentage ?? default; set => _destructionPercentage = value; }
 
         public List<ClanWarMember> Members { get; set; } = default!;
     }

--- a/src/ClashOfClans.Models/ClanWarLogEntry.cs
+++ b/src/ClashOfClans.Models/ClanWarLogEntry.cs
@@ -5,12 +5,13 @@ namespace ClashOfClans.Models
     public class ClanWarLogEntry
     {
         private DateTime? _endTime;
+        private int? _teamSize;
 
         public Result? Result { get; set; }
 
         public DateTime EndTime { get => _endTime ?? default; set => _endTime = value; }
 
-        public int? TeamSize { get; set; }
+        public int TeamSize { get => _teamSize ?? default; set => _teamSize = value; }
 
         public WarClan Clan { get; set; } = default!;
 

--- a/src/ClashOfClans.Models/ClanWarLogEntry.cs
+++ b/src/ClashOfClans.Models/ClanWarLogEntry.cs
@@ -4,9 +4,11 @@ namespace ClashOfClans.Models
 {
     public class ClanWarLogEntry
     {
+        private DateTime? _endTime;
+
         public Result? Result { get; set; }
 
-        public DateTime EndTime { get; set; }
+        public DateTime EndTime { get => _endTime ?? default; set => _endTime = value; }
 
         public int? TeamSize { get; set; }
 

--- a/src/ClashOfClans.Models/ClanWarMember.cs
+++ b/src/ClashOfClans.Models/ClanWarMember.cs
@@ -2,13 +2,17 @@
 {
     public class ClanWarMember : Identity
     {
-        public int? TownhallLevel { get; set; }
+        private int? _townhallLevel;
+        private int? _mapPosition;
+        private int? _opponentAttacks;
 
-        public int? MapPosition { get; set; }
+        public int TownhallLevel { get => _townhallLevel ?? default; set => _townhallLevel = value; }
+
+        public int MapPosition { get => _mapPosition ?? default; set => _mapPosition = value; }
 
         public ClanWarAttackList? Attacks { get; set; }
 
-        public int? OpponentAttacks { get; set; }
+        public int OpponentAttacks { get => _opponentAttacks ?? default; set => _opponentAttacks = value; }
 
         public ClanWarAttack? BestOpponentAttack { get; set; }
     }

--- a/src/ClashOfClans.Models/Label.cs
+++ b/src/ClashOfClans.Models/Label.cs
@@ -2,7 +2,9 @@
 {
     public class Label
     {
-        public int? Id { get; set; }
+        private int? _id;
+
+        public int Id { get => _id ?? default; set => _id = value; }
 
         public string Name { get; set; } = default!;
 

--- a/src/ClashOfClans.Models/League.cs
+++ b/src/ClashOfClans.Models/League.cs
@@ -2,7 +2,9 @@
 {
     public class League
     {
-        public int? Id { get; set; }
+        private int? _id;
+
+        public int Id { get => _id ?? default; set => _id = value; }
 
         public string Name { get; set; } = default!;
 

--- a/src/ClashOfClans.Models/LegendLeagueTournamentSeasonResult.cs
+++ b/src/ClashOfClans.Models/LegendLeagueTournamentSeasonResult.cs
@@ -2,10 +2,12 @@
 {
     public class LegendLeagueTournamentSeasonResult
     {
+        private int? _trophies;
+
         public string? Id { get; set; }
 
         public int? Rank { get; set; }
 
-        public int? Trophies { get; set; }
+        public int Trophies { get => _trophies ?? default; set => _trophies = value; }
     }
 }

--- a/src/ClashOfClans.Models/Location.cs
+++ b/src/ClashOfClans.Models/Location.cs
@@ -2,11 +2,14 @@
 {
     public class Location
     {
-        public int? Id { get; set; }
+        private int? _id;
+        private bool? _isCountry;
+
+        public int Id { get => _id ?? default; set => _id = value; }
 
         public string Name { get; set; } = default!;
 
-        public bool? IsCountry { get; set; }
+        public bool IsCountry { get => _isCountry ?? default; set => _isCountry = value; }
 
         public string? CountryCode { get; set; }
     }

--- a/src/ClashOfClans.Models/Player.cs
+++ b/src/ClashOfClans.Models/Player.cs
@@ -2,56 +2,70 @@
 {
     public class Player : Identity
     {
-        public int? TownHallLevel { get; set; }
+        private int? _townHallLevel;
+        private int? _expLevel;
+        private int? _trophies;
+        private int? _bestTrophies;
+        private int? _warStars;
+        private int? _attackWins;
+        private int? _defenseWins;
+        private int? _versusTrophies;
+        private int? _bestVersusTrophies;
+        private int? _versusBattleWins;
+        private int? _donations;
+        private int? _donationsReceived;
+        private int? _versusBattleWinCount;
+
+        public int TownHallLevel { get => _townHallLevel ?? default; set => _townHallLevel = value; }
 
         public int? TownHallWeaponLevel { get; set; }
 
-        public int? ExpLevel { get; set; }
+        public int ExpLevel { get => _expLevel ?? default; set => _expLevel = value; }
 
-        public int? Trophies { get; set; }
+        public int Trophies { get => _trophies ?? default; set => _trophies = value; }
 
         /// <summary>
         /// All time best
         /// </summary>
-        public int? BestTrophies { get; set; }
+        public int BestTrophies { get => _bestTrophies ?? default; set => _bestTrophies = value; }
 
         /// <summary>
         /// War stars won
         /// </summary>
-        public int? WarStars { get; set; }
+        public int WarStars { get => _warStars ?? default; set => _warStars = value; }
 
         /// <summary>
         /// Attacks won
         /// </summary>
-        public int? AttackWins { get; set; }
+        public int AttackWins { get => _attackWins ?? default; set => _attackWins = value; }
 
         /// <summary>
         /// Defenses won
         /// </summary>
-        public int? DefenseWins { get; set; }
+        public int DefenseWins { get => _defenseWins ?? default; set => _defenseWins = value; }
 
         public int? BuilderHallLevel { get; set; }
 
-        public int? VersusTrophies { get; set; }
+        public int VersusTrophies { get => _versusTrophies ?? default; set => _versusTrophies = value; }
 
         /// <summary>
         /// All time best
         /// </summary>
-        public int? BestVersusTrophies { get; set; }
+        public int BestVersusTrophies { get => _bestVersusTrophies ?? default; set => _bestVersusTrophies = value; }
 
-        public int? VersusBattleWins { get; set; }
+        public int VersusBattleWins { get => _versusBattleWins ?? default; set => _versusBattleWins = value; }
 
         public Role? Role { get; set; }
 
         /// <summary>
         /// Troops donated
         /// </summary>
-        public int? Donations { get; set; }
+        public int Donations { get => _donations ?? default; set => _donations = value; }
 
         /// <summary>
         /// Troops received
         /// </summary>
-        public int? DonationsReceived { get; set; }
+        public int DonationsReceived { get => _donationsReceived ?? default; set => _donationsReceived = value; }
 
         public PlayerClan? Clan { get; set; }
 
@@ -61,7 +75,7 @@
 
         public PlayerAchievementProgressList Achievements { get; set; } = default!;
 
-        public int? VersusBattleWinCount { get; set; }
+        public int VersusBattleWinCount { get => _versusBattleWinCount ?? default; set => _versusBattleWinCount = value; }
 
         public PlayerItemLevelList Troops { get; set; } = default!;
 

--- a/src/ClashOfClans.Models/PlayerAchievementProgress.cs
+++ b/src/ClashOfClans.Models/PlayerAchievementProgress.cs
@@ -2,18 +2,23 @@
 {
     public class PlayerAchievementProgress
     {
+        private int? _stars;
+        private int? _value;
+        private int? _target;
+        private Village? _village;
+
         public string Name { get; set; } = default!;
 
-        public int? Stars { get; set; }
+        public int Stars { get => _stars ?? default; set => _stars = value; }
 
-        public int? Value { get; set; }
+        public int Value { get => _value ?? default; set => _value = value; }
 
-        public int? Target { get; set; }
+        public int Target { get => _target ?? default; set => _target = value; }
 
         public string Info { get; set; } = default!;
 
         public string? CompletionInfo { get; set; }
 
-        public Village? Village { get; set; }
+        public Village Village { get => _village ?? default; set => _village = value; }
     }
 }

--- a/src/ClashOfClans.Models/PlayerClan.cs
+++ b/src/ClashOfClans.Models/PlayerClan.cs
@@ -2,7 +2,9 @@
 {
     public class PlayerClan : Identity
     {
-        public int? ClanLevel { get; set; }
+        private int? _clanLevel;
+
+        public int ClanLevel { get => _clanLevel ?? default; set => _clanLevel = value; }
 
         public UrlContainer BadgeUrls { get; set; } = default!;
     }

--- a/src/ClashOfClans.Models/PlayerItemLevel.cs
+++ b/src/ClashOfClans.Models/PlayerItemLevel.cs
@@ -2,12 +2,16 @@
 {
     public class PlayerItemLevel
     {
+        private int? _level;
+        private int? _maxLevel;
+        private Village? _village;
+
         public string Name { get; set; } = default!;
 
-        public int? Level { get; set; }
+        public int Level { get => _level ?? default; set => _level = value; }
 
-        public int? MaxLevel { get; set; }
+        public int MaxLevel { get => _maxLevel ?? default; set => _maxLevel = value; }
 
-        public Village? Village { get; set; }
+        public Village Village { get => _village ?? default; set => _village = value; }
     }
 }

--- a/src/ClashOfClans.Models/PlayerLegendStatistics.cs
+++ b/src/ClashOfClans.Models/PlayerLegendStatistics.cs
@@ -2,7 +2,9 @@
 {
     public class PlayerLegendStatistics
     {
-        public int? LegendTrophies { get; set; }
+        private int? _legendTrophies;
+
+        public int LegendTrophies { get => _legendTrophies ?? default; set => _legendTrophies = value; }
 
         public LegendLeagueTournamentSeasonResult? BestVersusSeason { get; set; }
 

--- a/src/ClashOfClans.Models/PlayerRanking.cs
+++ b/src/ClashOfClans.Models/PlayerRanking.cs
@@ -2,15 +2,21 @@
 {
     public class PlayerRanking : Identity
     {
-        public int? ExpLevel { get; set; }
+        private int? _expLevel;
+        private int? _trophies;
+        private int? _attackWins;
+        private int? _defenseWins;
+        private int? _rank;
 
-        public int? Trophies { get; set; }
+        public int ExpLevel { get => _expLevel ?? default; set => _expLevel = value; }
 
-        public int? AttackWins { get; set; }
+        public int Trophies { get => _trophies ?? default; set => _trophies = value; }
 
-        public int? DefenseWins { get; set; }
+        public int AttackWins { get => _attackWins ?? default; set => _attackWins = value; }
 
-        public int? Rank { get; set; }
+        public int DefenseWins { get => _defenseWins ?? default; set => _defenseWins = value; }
+
+        public int Rank { get => _rank ?? default; set => _rank = value; }
 
         public int? PreviousRank { get; set; }
 

--- a/src/ClashOfClans.Models/PlayerVersusRanking.cs
+++ b/src/ClashOfClans.Models/PlayerVersusRanking.cs
@@ -2,15 +2,21 @@
 {
     public class PlayerVersusRanking : Identity
     {
-        public int? ExpLevel { get; set; }
+        private int? _expLevel;
+        private int? _rank;
+        private int? _previousRank;
+        private int? _versusTrophies;
+        private int? _versusBattleWins;
 
-        public int? Rank { get; set; }
+        public int ExpLevel { get => _expLevel ?? default; set => _expLevel = value; }
 
-        public int? PreviousRank { get; set; }
+        public int Rank { get => _rank ?? default; set => _rank = value; }
 
-        public int? VersusTrophies { get; set; }
+        public int PreviousRank { get => _previousRank ?? default; set => _previousRank = value; }
 
-        public int? VersusBattleWins { get; set; }
+        public int VersusTrophies { get => _versusTrophies ?? default; set => _versusTrophies = value; }
+
+        public int VersusBattleWins { get => _versusBattleWins ?? default; set => _versusBattleWins = value; }
 
         public PlayerRankingClan? Clan { get; set; }
     }

--- a/src/ClashOfClans.Models/WarBase.cs
+++ b/src/ClashOfClans.Models/WarBase.cs
@@ -7,10 +7,12 @@ namespace ClashOfClans.Models
         private DateTime? _preparationStartTime;
         private DateTime? _startTime;
         private DateTime? _endTime;
+        private State? _state;
+        private int? _teamSize;
 
-        public State? State { get; set; }
+        public State State { get => _state ?? default; set => _state = value; }
 
-        public int? TeamSize { get; set; }
+        public int TeamSize { get => _teamSize ?? default; set => _teamSize = value; }
 
         public DateTime PreparationStartTime { get => _preparationStartTime ?? default; set => _preparationStartTime = value; }
 

--- a/src/ClashOfClans.Models/WarBase.cs
+++ b/src/ClashOfClans.Models/WarBase.cs
@@ -4,14 +4,18 @@ namespace ClashOfClans.Models
 {
     public abstract class WarBase
     {
+        private DateTime? _preparationStartTime;
+        private DateTime? _startTime;
+        private DateTime? _endTime;
+
         public State? State { get; set; }
 
         public int? TeamSize { get; set; }
 
-        public DateTime PreparationStartTime { get; set; }
+        public DateTime PreparationStartTime { get => _preparationStartTime ?? default; set => _preparationStartTime = value; }
 
-        public DateTime StartTime { get; set; }
+        public DateTime StartTime { get => _startTime ?? default; set => _startTime = value; }
 
-        public DateTime EndTime { get; set; }
+        public DateTime EndTime { get => _endTime ?? default; set => _endTime = value; }
     }
 }

--- a/src/ClashOfClans.Models/WarClan.cs
+++ b/src/ClashOfClans.Models/WarClan.cs
@@ -2,19 +2,23 @@
 {
     public class WarClan
     {
+        private int? _clanLevel;
+        private int? _stars;
+        private float? _destructionPercentage;
+
         public string? Tag { get; set; }
 
         public string? Name { get; set; }
 
         public UrlContainer BadgeUrls { get; set; } = default!;
 
-        public int? ClanLevel { get; set; }
+        public int ClanLevel { get => _clanLevel ?? default; set => _clanLevel = value; }
 
         public int? Attacks { get; set; }
 
-        public int? Stars { get; set; }
+        public int Stars { get => _stars ?? default; set => _stars = value; }
 
-        public float? DestructionPercentage { get; set; }
+        public float DestructionPercentage { get => _destructionPercentage ?? default; set => _destructionPercentage = value; }
 
         public int? ExpEarned { get; set; }
 

--- a/src/ClashOfClans.Models/WarLeague.cs
+++ b/src/ClashOfClans.Models/WarLeague.cs
@@ -2,7 +2,9 @@
 {
     public class WarLeague
     {
-        public int? Id { get; set; }
+        private int? _id;
+
+        public int Id { get => _id ?? default; set => _id = value; }
 
         public string Name { get; set; } = default!;
     }

--- a/src/ClashOfClans.Tests.Integration/ClansTests.cs
+++ b/src/ClashOfClans.Tests.Integration/ClansTests.cs
@@ -136,7 +136,7 @@ namespace ClashOfClans.Tests.Integration
             var taskList = new List<Task<QueryResult<ClanWarLog>>>();
 
             // Act
-            foreach (var clan in _clans.Where(c => c.IsWarLogPublic == true))
+            foreach (var clan in _clans.Where(c => c.IsWarLogPublic))
             {
                 taskList.Add(_coc.Clans.GetClanWarLogAsync(clan.Tag));
             }
@@ -156,12 +156,12 @@ namespace ClashOfClans.Tests.Integration
         {
             // Arrange
             var taskList = new List<Task<ClanWar>>();
-            var clanTags = _clans.Where(c => c.IsWarLogPublic == true).Select(c => c.Tag).ToList();
+            var clanTags = _clans.Where(c => c.IsWarLogPublic).Select(c => c.Tag).ToList();
 
             foreach (var clanTag in ClanTags)
             {
                 var clan = await _coc.Clans.GetClanAsync(clanTag);
-                if (clan.IsWarLogPublic == true)
+                if (clan.IsWarLogPublic)
                     clanTags.Add(clan.Tag);
             }
 
@@ -183,7 +183,7 @@ namespace ClashOfClans.Tests.Integration
         {
             // Arrange
             var taskList = new List<Task<ClanWarLeagueGroup>>();
-            var clanTags = _clans.Where(c => c.IsWarLogPublic == true).Select(c => c.Tag).ToList();
+            var clanTags = _clans.Where(c => c.IsWarLogPublic).Select(c => c.Tag).ToList();
             clanTags.AddRange(ClanTags);
 
             // Act

--- a/src/ClashOfClans.Tests.Integration/DumpExtensions.cs
+++ b/src/ClashOfClans.Tests.Integration/DumpExtensions.cs
@@ -162,8 +162,8 @@ namespace ClashOfClans.Tests.Integration
             {
                 foreach (var member in list)
                 {
-                    int donations = (int)member.Donations!;
-                    int donationsReceived = (int)member.DonationsReceived!;
+                    int donations = member.Donations;
+                    int donationsReceived = member.DonationsReceived;
 
                     sb.Append($"{member.Tag}/{member.Name}, donations {donations}/{donationsReceived}");
                     sb.Append($"={((donationsReceived != 0) ? donations / (float)donationsReceived : -1)}");

--- a/src/ClashOfClans.Tests.Integration/LocationsTests.cs
+++ b/src/ClashOfClans.Tests.Integration/LocationsTests.cs
@@ -87,7 +87,7 @@ namespace ClashOfClans.Tests.Integration
         public async Task GetClanRankingsForASpecificLocation()
         {
             // Arrange
-            var location = GetRandom(_locations, l => l.IsCountry == true);
+            var location = GetRandom(_locations, l => l.IsCountry);
             var query = new Query
             {
                 Limit = ItemLimit
@@ -105,7 +105,7 @@ namespace ClashOfClans.Tests.Integration
         public async Task GetPlayerRankingsForASpecificLocation()
         {
             // Arrange
-            var location = GetRandom(_locations, l => l.IsCountry == true);
+            var location = GetRandom(_locations, l => l.IsCountry);
             var query = new Query
             {
                 Limit = ItemLimit
@@ -123,7 +123,7 @@ namespace ClashOfClans.Tests.Integration
         public async Task GetClanVersusRankingsForASpecificLocation()
         {
             // Arrange
-            var location = GetRandom(_locations, l => l.IsCountry == true);
+            var location = GetRandom(_locations, l => l.IsCountry);
             var query = new Query
             {
                 Limit = ItemLimit
@@ -141,7 +141,7 @@ namespace ClashOfClans.Tests.Integration
         public async Task GetPlayerVersusRankingsForASpecificLocation()
         {
             // Arrange
-            var location = GetRandom(_locations, l => l.IsCountry == true);
+            var location = GetRandom(_locations, l => l.IsCountry);
             var query = new Query
             {
                 Limit = ItemLimit

--- a/src/ClashOfClans.Tests.Unit/ExtensionsTests.cs
+++ b/src/ClashOfClans.Tests.Unit/ExtensionsTests.cs
@@ -1,0 +1,57 @@
+﻿using ClashOfClans.Extensions;
+using ClashOfClans.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace ClashOfClans.Models
+{
+    internal class NullableTypes
+    {
+        public Role? NullableRole { get; set; }
+        public Player? NullablePlayer { get; set; }
+        public int? NullableTrophies { get; set; }
+    }
+
+    internal class NonnullableTypes
+    {
+        private Role? _nonnullableRole;
+        private int? _nonnullableTrophies;
+
+        public Role NonnullableRole { get => _nonnullableRole ?? default; set => _nonnullableRole = value; }
+        public Player NonnullablePlayer { get; set; } = default!;
+        public int NonnullableTrophies { get => _nonnullableTrophies ?? default; set => _nonnullableTrophies = value; }
+    }
+}
+
+namespace ClashOfClans.Tests.Unit
+{
+    [TestClass]
+    public class ExtensionsTests
+    {
+        [TestMethod]
+        public void NullPropertiesFoundFromNullableObject()
+        {
+            // Arrange
+            var nullableTypes = new NullableTypes();
+
+            // Act
+            var nullProperties = nullableTypes.GetNullMembers();
+
+            // Assert
+            Assert.AreEqual(3, nullProperties.Count());
+        }
+
+        [TestMethod]
+        public void NullPropertiesFoundFromNonnullableObject()
+        {
+            // Arrange
+            var nonnullableTypes = new NonnullableTypes();
+
+            // Act
+            var nullProperties = nonnullableTypes.GetNullMembers();
+
+            // Assert
+            Assert.AreEqual(3, nullProperties.Count());
+        }
+    }
+}

--- a/src/ClashOfClans/Core/GameData.cs
+++ b/src/ClashOfClans/Core/GameData.cs
@@ -56,7 +56,7 @@ namespace ClashOfClans.Core
             var deserializedData = _serializer.Deserialize<T>(data);
 
 #if DEBUG
-            var nullProperties = deserializedData.GetNullProperties();
+            var nullProperties = deserializedData.GetNullMembers();
 
             lock (_nullProperties)
                 _nullProperties.UnionWith(nullProperties);


### PR DESCRIPTION
Fixes #37 by implementing a nullable backing field for non-nullable value types in order to track when value type that currently always have value might be null. Based on the current understanding the value types that might be null is kept as nullable value types in the models but other value types have been defined as normal value types.