### PR TITLE
Publish symbol package to nuget.org

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -1,9 +1,14 @@
 # https://docs.microsoft.com/en-us/nuget/concepts/package-versioning : Major.Minor.Patch[-Suffix]
 $packageVersion = Get-Content .\version.txt -Tail 1
-$project = "..\src\ClashOfClans\ClashOfClans.csproj"
+$packageId = "ClashOfClans"
+$basePath = "..\src\ClashOfClans\"
+$project =  $basePath + $packageId + ".csproj"
+$nuspec = $basePath + $packageId + ".nuspec"
+$nupkg = "$packageId.$packageVersion.nupkg"
 $configuration = "Release"
 
 dotnet clean -c $configuration $project
-dotnet pack -p:PackageVersion=$packageVersion -p:Version=$packageVersion -c $configuration $project
+dotnet build -c $configuration $project -p:Version=$packageVersion
 
-nuget push ..\src\ClashOfClans\bin\$configuration\ClashOfClans.$packageVersion.nupkg -ApiKey ${env:NUGET_API_KEY} -Source https://api.nuget.org/v3/index.json
+nuget pack $nuspec -Properties Version=$packageVersion -Symbols -SymbolPackageFormat snupkg
+nuget push $nupkg -ApiKey ${env:NUGET_API_KEY} -Source https://api.nuget.org/v3/index.json

--- a/build/version.txt
+++ b/build/version.txt
@@ -6,4 +6,4 @@
 #   Patch: Backwards compatible bug fixes only
 #   -Suffix (optional): a hyphen followed by a string denoting a pre-release version (rc1, rc2, etc.)
 
-8.0.0
+8.0.1-rc1

--- a/src/ClashOfClans/ClashOfClans.nuspec
+++ b/src/ClashOfClans/ClashOfClans.nuspec
@@ -28,10 +28,13 @@
   <files>
     <file src="..\..\docfx\images\icon.png" target="" />
     <file src="bin\Release\netstandard2.0\*.dll" target="lib\netstandard2.0" />
+    <file src="bin\Release\netstandard2.0\*.pdb" target="lib\netstandard2.0" />
     <file src="bin\Release\netstandard2.0\ClashOfClans.xml" target="lib\netstandard2.0" />
     <file src="bin\Release\netstandard2.1\*.dll" target="lib\netstandard2.1" />
+    <file src="bin\Release\netstandard2.1\*.pdb" target="lib\netstandard2.1" />
     <file src="bin\Release\netstandard2.1\ClashOfClans.xml" target="lib\netstandard2.1" />
     <file src="bin\Release\netcoreapp3.0\*.dll" target="lib\netcoreapp3.0" />
+    <file src="bin\Release\netcoreapp3.0\*.pdb" target="lib\netcoreapp3.0" />
     <file src="bin\Release\netcoreapp3.0\ClashOfClans.xml" target="lib\netcoreapp3.0" />
   </files>
 </package>


### PR DESCRIPTION
Adds a support for publishing symbol package to nuget.org automatically for every new release.

Instructions how to use symbol package can be found from: https://devblogs.microsoft.com/dotnet/improving-debug-time-productivity-with-source-link/