### PR TITLE
Move Binder to own README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN dotnet_sdk_version=6.0.100 \
   && dotnet help
 
 # Copy notebooks
-COPY ./notebooks/ ${HOME}/Notebooks/
+COPY ./notebooks/*.ipynb ${HOME}/Notebooks/
 
 # Add package sources
 RUN echo "\

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Version](https://img.shields.io/nuget/v/ClashOfClans.svg)](https://www.nuget.org/packages/ClashOfClans)
 ![Downloads](https://img.shields.io/nuget/dt/ClashOfClans.svg)
 [![License](https://img.shields.io/github/license/tparviainen/clashofclans.svg)](https://github.com/tparviainen/clashofclans/blob/develop/LICENSE)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tparviainen/clashofclans/develop?urlpath=lab)
 
 .NET library for accessing Supercell's [Clash of Clans API](https://developer.clashofclans.com/).
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -16,5 +16,6 @@ After the image is running the output contains the URL to open in a browser:
 
 ```
 notebooks-clashofclans-1  |     Or copy and paste one of these URLs:
+notebooks-clashofclans-1  |      ...
 notebooks-clashofclans-1  |      or http://127.0.0.1:8888/?token=bc092f54d4218e10f16ad27609c60742b9a51193bb6de4cd
 ```

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -16,6 +16,5 @@ After the image is running the output contains the URL to open in a browser:
 
 ```
 notebooks-clashofclans-1  |     Or copy and paste one of these URLs:
-notebooks-clashofclans-1  |         http://90af265adfde:8888/?token=bc092f54d4218e10f16ad27609c60742b9a51193bb6de4cd
 notebooks-clashofclans-1  |      or http://127.0.0.1:8888/?token=bc092f54d4218e10f16ad27609c60742b9a51193bb6de4cd
 ```

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,21 @@
+# Info
+
+This folder contains C# notebooks for testing the functionality of the ClashOfClans library. The main purpose for these notebooks is to allow anyone to try the ClashOfClans library and its functionality without having own local development environment!
+
+You can try the interactive notebooks by clicking the [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tparviainen/clashofclans/develop?urlpath=lab) which creates an executable environment available via web browser. After the environment is built open `00-README.ipynb` notebook and follow the instructions to setup API token etc.
+
+# Local
+
+If you already have Docker in your local development environment you can build the Docker image locally and start it by giving the next command in the `notebooks` folder:
+
+```
+docker-compose up --build
+```
+
+After the image is running the output contains the URL to open in a browser:
+
+```
+notebooks-clashofclans-1  |     Or copy and paste one of these URLs:
+notebooks-clashofclans-1  |         http://90af265adfde:8888/?token=bc092f54d4218e10f16ad27609c60742b9a51193bb6de4cd
+notebooks-clashofclans-1  |      or http://127.0.0.1:8888/?token=bc092f54d4218e10f16ad27609c60742b9a51193bb6de4cd
+```

--- a/notebooks/docker-compose.yml
+++ b/notebooks/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+
+services:
+  clashofclans:
+    build:
+      context: ..
+    ports:
+      - "8888:8888"
+    command: jupyter notebook --NotebookApp.default_url=/lab/ --ip=0.0.0.0 --port=8888


### PR DESCRIPTION
Move Binder related information to own README.md file so that README.md in the root is suitable for NuGet.org