### PR TITLE
Add support for .NET6 and .NET7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,25 +3,25 @@ name: build
 on:
   push:
     paths:
-      - 'src/**'
+      - "src/**"
     branches:
       - main
       - develop
   pull_request:
     paths:
-      - 'src/**'
+      - "src/**"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: | 
-          3.1.x
-          6.0.x
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            6.0.x
+            7.0.x
 
-    - name: Build with dotnet
-      run: dotnet build ./src/ClashOfClans.sln
+      - name: Build with dotnet
+        run: dotnet build ./src/ClashOfClans.sln

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -3,9 +3,9 @@ name: docs
 on:
   push:
     paths:
-      - 'docfx/**'
-      - 'src/ClashOfClans/**'
-      - 'src/ClashOfClans.Models/**'
+      - "docfx/**"
+      - "src/ClashOfClans/**"
+      - "src/ClashOfClans.Models/**"
     branches:
       - develop
 
@@ -14,32 +14,32 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - run: git config --global user.name ${env:GITHUB_ACTOR}
-    - run: git config --global user.email ${env:GITHUB_ACTOR}@users.noreply.github.com
+      - run: git config --global user.name ${env:GITHUB_ACTOR}
+      - run: git config --global user.email ${env:GITHUB_ACTOR}@users.noreply.github.com
 
-    - uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.DOCFX_API_KEY }}
-    - uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '6.0.x'
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.DOCFX_API_KEY }}
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "7.0.x"
 
-    - name: Build with dotnet
-      run: dotnet build ./src/ClashOfClans/ClashOfClans.csproj
+      - name: Build with dotnet
+        run: dotnet build ./src/ClashOfClans/ClashOfClans.csproj
 
-    - name: Setup DocFX
-      run: choco install docfx
+      - name: Setup DocFX
+        run: choco install docfx
 
-    - name: Build with DocFX
-      working-directory: docfx
-      run: |
-        Remove-Item ../docs/ -Recurse
-        docfx
+      - name: Build with DocFX
+        working-directory: docfx
+        run: |
+          Remove-Item ../docs/ -Recurse
+          docfx
 
-    - name: Stage all changes
-      run: git add -A
+      - name: Stage all changes
+        run: git add -A
 
-    - name: Update GitHub Pages
-      run: |
-        git commit -am "Update GitHub Pages"
-        git push
+      - name: Update GitHub Pages
+        run: |
+          git commit -am "Update GitHub Pages"
+          git push

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: "7.0.x"
 
       - name: Setup NuGet CLI
         run: choco install nuget.commandline

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,26 +3,26 @@ name: tests
 on:
   push:
     paths:
-      - 'src/ClashOfClans/**'
-      - 'src/ClashOfClans.Tests.Unit/**'
+      - "src/ClashOfClans/**"
+      - "src/ClashOfClans.Tests.Unit/**"
     branches:
       - main
       - develop
   pull_request:
     paths:
-      - 'src/ClashOfClans/**'
-      - 'src/ClashOfClans.Tests.Unit/**'
+      - "src/ClashOfClans/**"
+      - "src/ClashOfClans.Tests.Unit/**"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '6.0.x'
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "7.0.x"
 
-    - name: Unit Tests
-      working-directory: src
-      run: dotnet test --filter FullyQualifiedName~ClashOfClans.Tests.Unit
+      - name: Unit Tests
+        working-directory: src
+        run: dotnet test --filter FullyQualifiedName~ClashOfClans.Tests.Unit

--- a/build/version.txt
+++ b/build/version.txt
@@ -6,4 +6,4 @@
 #   Patch: Backwards compatible bug fixes only
 #   -Suffix (optional): a hyphen followed by a string denoting a pre-release version (rc1, rc2, etc.)
 
-8.5.0-rc1
+8.5.0-rc2

--- a/src/ClashOfClans.App/ClashOfClans.App.csproj
+++ b/src/ClashOfClans.App/ClashOfClans.App.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClashOfClans" Version="8.5.0-rc1" />
+    <PackageReference Include="ClashOfClans" Version="8.5.0-rc2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/ClashOfClans.Models/ClashOfClans.Models.csproj
+++ b/src/ClashOfClans.Models/ClashOfClans.Models.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>

--- a/src/ClashOfClans/ClashOfClans.csproj
+++ b/src/ClashOfClans/ClashOfClans.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NuspecFile>ClashOfClans.nuspec</NuspecFile>
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/ClashOfClans/ClashOfClans.nuspec
+++ b/src/ClashOfClans/ClashOfClans.nuspec
@@ -21,7 +21,10 @@
       <group targetFramework="netstandard2.1">
         <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
       </group>
-      <group targetFramework="netcoreapp3.1">
+      <group targetFramework="net6.0">
+        <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net7.0">
         <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
       </group>
     </dependencies>
@@ -35,8 +38,11 @@
     <file src="bin\Release\netstandard2.1\*.dll" target="lib\netstandard2.1" />
     <file src="bin\Release\netstandard2.1\*.pdb" target="lib\netstandard2.1" />
     <file src="bin\Release\netstandard2.1\ClashOfClans.xml" target="lib\netstandard2.1" />
-    <file src="bin\Release\netcoreapp3.1\*.dll" target="lib\netcoreapp3.1" />
-    <file src="bin\Release\netcoreapp3.1\*.pdb" target="lib\netcoreapp3.1" />
-    <file src="bin\Release\netcoreapp3.1\ClashOfClans.xml" target="lib\netcoreapp3.1" />
+    <file src="bin\Release\net6.0\*.dll" target="lib\net6.0" />
+    <file src="bin\Release\net6.0\*.pdb" target="lib\net6.0" />
+    <file src="bin\Release\net6.0\ClashOfClans.xml" target="lib\net6.0" />
+    <file src="bin\Release\net7.0\*.dll" target="lib\net7.0" />
+    <file src="bin\Release\net7.0\*.pdb" target="lib\net7.0" />
+    <file src="bin\Release\net7.0\ClashOfClans.xml" target="lib\net7.0" />
   </files>
 </package>


### PR DESCRIPTION
Adds a support for .NET6 and .NET6 and removes netcoreapp3.1 due the fact that several NuGet packages do not support it instead there are lots of warnings in build:

```
warning : Microsoft.Extensions.Configuration.Abstractions 7.0.0 doesn't support netcoreapp3.1 and has not been tested with it. Consider upgrading your TargetFramework to net6.0 or later. You may also set <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings> in the project file to ignore this warning and attempt to run in this unsupported configuration at your own risk. [/clashofclans/src/ClashOfClans/ClashOfClans.csproj::TargetFramework=netcoreapp3.1]
```